### PR TITLE
fix: Fixed link to see supported framework 

### DIFF
--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -68,4 +68,4 @@ port := "8080"
  })
 ```
 
-Now wrap the routers, https clients and external dependencies like DBs. See the list of [supported frameworks](http://localhost:3000/docs/go/supported-frameworks).
+Now wrap the routers, https clients and external dependencies like DBs. See the list of [supported frameworks](/docs/go/supported-frameworks).

--- a/docs/go/installation.md
+++ b/docs/go/installation.md
@@ -68,4 +68,4 @@ port := "8080"
  })
 ```
 
-Now wrap the routers, https clients and external dependencies like DBs. See the list of [supported frameworks](http://localhost:3000/docs/go/supported-frameworks).
+Now wrap the routers, https clients and external dependencies like DBs. See the list of [supported frameworks](/docs/go/supported-frameworks).


### PR DESCRIPTION
Signed-off-by: SanskritiHarmukh <sanskritiharmukh1908@gmail.com>

## Description

Changed the link to supported frameworks in the go section that was broken before. Created a new pull request for this issue as previous one had too many changes when I pulled before pushing. 

I have run the changes locally. Working fine now.

Fixes #43 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?
I have run the changes locally. Working fine now.

![Screenshot from 2022-09-24 17-10-59](https://user-images.githubusercontent.com/74777863/192096223-1559a3e9-ef54-4f9f-bdfe-a5114e68b438.png)

## Additional Context (Please include any Screenshots/gifs if relevant)
Now as soon as you click the link it's opening in the same tab.

![Screenshot from 2022-09-24 17-10-05](https://user-images.githubusercontent.com/74777863/192096227-83fbfd3f-17c6-4e3f-bbbc-67f38a2bc19a.png)

![Screenshot from 2022-09-24 17-10-21](https://user-images.githubusercontent.com/74777863/192096229-530495f5-4245-4008-8bf8-0deaf063a913.png)



## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding tests.
- [ ] Any dependent changes have been merged and published in downstream modules.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
