### PR TITLE
Closes #49 - firefox operating guide bullets and text alignment fix

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -512,3 +512,7 @@ div[class^='announcementBar_'] {
   );
   font-weight: bold;
 }
+
+.list-disc > a {
+	display: inherit
+}


### PR DESCRIPTION
## Description

- Added firefox operating guide bullets and text alignment fix

Fixes # (49)

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

- Manual

## Additional Context:
![image](https://user-images.githubusercontent.com/14018471/193428878-c1e03d4e-7eef-4447-abab-0bd6f8b31a8e.png)
...

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
