### PR TITLE
fix(sidebar): Java SDK installation link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -141,7 +141,7 @@ module.exports = {
         {
           type: "doc",
           label: "Installation",
-          id: "go/installation",
+          id: "java/installation",
         },
 
         // Integration


### PR DESCRIPTION
# Pull Request Template

## Description

The link to next button for `Java SDK Integartion` in keploy server installation page need to be updated for Java.

Fixes https://github.com/keploy/keploy/issues/321

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding tests.
- [ ] Any dependent changes have been merged and published in downstream modules.
