### PR TITLE
Correcting alignment of home icon in navbar breadcrumbs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -525,7 +525,7 @@ div[class^="announcementBar_"] {
   display: inherit;
 }
 
-/*Correcting alignment of home icon innavbar breadcrumbs*/
+/*Correcting alignment of home icon in navbar breadcrumbs*/
 a[class="breadcrumbs__link"]{
   margin-bottom: -10px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -524,3 +524,8 @@ div[class^="announcementBar_"] {
 .list-disc > a {
   display: inherit;
 }
+
+/*Correcting alignment of home icon innavbar breadcrumbs*/
+a[class="breadcrumbs__link"]{
+  margin-bottom: -10px;
+}


### PR DESCRIPTION
## Description
It is a simple bug causing alignment issues fixed by custom code targeting the element.

Fixes # #325

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?
It has been tested locally.

## Additional Context (Please include any Screenshots/gifs if relevant)
Before:
DESKTOP
![image](https://user-images.githubusercontent.com/83979298/221980662-104a5107-ca6d-4657-9df8-a99536fb2567.png)

MOBILE
![image](https://user-images.githubusercontent.com/83979298/221980735-724d2a28-2fee-4340-8ad2-cad1f0d82767.png)

After:
DESKTOP
![image](https://user-images.githubusercontent.com/83979298/221980823-99211ad6-ac36-405b-bede-ae14073e7dca.png)

MOBILE
![image](https://user-images.githubusercontent.com/83979298/221980902-2bd4edb8-5da2-4fa1-85c2-655e8a12d1f7.png)

...

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
