### PR TITLE
Fixes 2 footers in documentation page

### DIFF
--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Footer from '@theme-original/Footer';
 
-export default function FooterWrapper(props) {
+export default function FooterWrapper() {
   return (
     <>
-      <Footer {...props} />
+      <Footer  />
     </>
   );
 }


### PR DESCRIPTION
Closes https://github.com/keploy/keploy/issues/320

Two footers are present on several documentation pages. I tried fixing the issue. Please take a look.

Signed off by nayanikasc2002@gmail.com