### PR TITLE
Updated index.js to fix 2 footer bug

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -96,7 +96,7 @@ export default function DocItem(props) {
                 </article>
               </div>
 
-              <FooterWrapper {...props} />
+              <FooterWrapper />
             </article>
 
             <DocPaginator previous={metadata.previous} next={metadata.next} />


### PR DESCRIPTION
Closes https://github.com/keploy/keploy/issues/320

Two footers are present on several documentation pages. I tried fixing the issue. Please take a look.

Signed off by nayanikasc2002@gmail.com