### PR TITLE
Fixing home icon alignment-added padding on top and margin on bottom

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -531,3 +531,9 @@ div[class^="announcementBar_"] {
 .list-disc > a {
   display: inherit;
 }
+
+/*Correcting alignment of home icon innavbar breadcrumbs*/
+a[class="breadcrumbs__link"]{
+  padding-top: 2px;
+  margin-bottom: -10px;
+}


### PR DESCRIPTION
## Description
It is a simple bug causing alignment issues fixed by custom code targeting the element.

Fixes #325 raised in keploy main repository.
https://github.com/keploy/keploy/issues/325Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?
Local Test

## Additional Context (Please include any Screenshots/gifs if relevant)
![image](https://user-images.githubusercontent.com/83979298/222955926-bc66c0b4-e362-4832-a937-b1ec97239254.png)

![image](https://user-images.githubusercontent.com/83979298/222955948-e6dcdff4-37e1-46df-a7fa-399515af1a0b.png)

...

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
