### PR TITLE
[docs] removed the extra image of Keploy console

### DIFF
--- a/docs/go/quickstart/gorillamux-redis.md
+++ b/docs/go/quickstart/gorillamux-redis.md
@@ -171,8 +171,6 @@ So no need to setup fake database/apis like Redis or write mocks for them. Keplo
 
 Go to the `Keploy Console` to get deeper insights on what testcases ran, what failed.
 
-![GorillaMux-Redis-Test-Run](/img/GorillaMux-Redis-test-runs.png)
-
 <details>
 <summary>𝗜𝗻𝘀𝗶𝗴𝗵𝘁𝘀 𝗼𝗻 𝗞𝗲𝗽𝗹𝗼𝘆 𝗖𝗼𝗻𝘀𝗼𝗹𝗲</summary>
 
@@ -201,11 +199,9 @@ Testrun passed for testcase with id: "test-1"
 
 
 ```
-
 </details>
 
 ---
-
 ### Make a code change
 
 Now try changing something like commenting line numbers 115 and 116 and uncommenting line 119 in [main.go](./main.go) and running ` go test -coverpkg=./... -covermode=atomic ./...` again


### PR DESCRIPTION
# Pull Request Template

## Description

The image of Keploy console is removed, as the same content is displayed using shell. 

Fixes [#557](https://github.com/keploy/keploy/issues/557)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)
![image](https://github.com/keploy/docs/assets/104296574/0df84ed4-416c-4a38-9a53-451ef7299e99)


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding tests.
- [x] Any dependent changes have been merged and published in downstream modules.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
