### PR TITLE
bug: redundant footer

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -17,7 +17,6 @@ import styles from "./styles.module.css";
 import {ThemeClassNames, useWindowSize} from "@docusaurus/theme-common";
 import DocBreadcrumbs from "@theme/DocBreadcrumbs";
 import Layout from "@docusaurus/core/lib/client/theme-fallback/Layout";
-import FooterWrapper from "../Footer";
 
 export default function DocItem(props) {
   const {content: DocContent} = props;
@@ -95,8 +94,6 @@ export default function DocItem(props) {
                   <DocContent />
                 </article>
               </div>
-
-              <FooterWrapper {...props} />
             </article>
 
             <DocPaginator previous={metadata.previous} next={metadata.next} />


### PR DESCRIPTION
## Description
If we go to:
- [https://docs.keploy.io/docs/keploy-explained/introduction](https://docs.keploy.io/docs/keploy-explained/introduction)
- [https://docs.keploy.io/docs/devtools/sdk-contrib-guide](https://docs.keploy.io/docs/devtools/sdk-contrib-guide)
- [https://docs.keploy.io/docs/gsoc/contribution-guide](https://docs.keploy.io/docs/gsoc/contribution-guide)
- [https://docs.keploy.io/docs/go/installation](https://docs.keploy.io/docs/go/installation)

...and almost every section of the website, we can see a redundant footer like in the screenshot floating at the bottom unnecessarily.

![footer](https://user-images.githubusercontent.com/77505989/240350458-f7478ae2-eb07-43e0-ac41-cd20a307d58d.png)

I have fixed the unnecessary import of this footer in the issue [#568](https://github.com/keploy/keploy/issues/568)

Fixes [#568](https://github.com/keploy/keploy/issues/568)
Fixes [#549](https://github.com/keploy/keploy/issues/549)

## Type of change
**UI - Website**

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?
Test locally as there is only one component that is used unnecessarily in one of the files.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
