### PR TITLE
 Fix: Typo in command for capturing test cases in sample bun.js documentation

### DIFF
--- a/versioned_docs/version-2.0.0/quickstart/samples-bunjs.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-bunjs.md
@@ -97,7 +97,7 @@ docker-compose up -d
 ### Capture the testcases
 
 ```bash
-sudo -E env PATH=$PATH Keploy record -c 'bun run supabun.ts'
+sudo -E env PATH=$PATH keploy record -c 'bun run supabun.ts'
 ```
 
 Make API Calls using [Hoppscotch](https://hoppscotch.io), [Postman](https://postman.com) or cURL command. Keploy with capture those calls to generate the test-suites containing testcases and data mocks.


### PR DESCRIPTION
# Description:
Resolves issue #1235 where the documentation for the sample bun.js contained a typo in the command for capturing test cases. The current command incorrectly references Keploy instead of the correct alias keploy.

## Changes Made:

Updated the documentation in bun.js to reflect the correct command for capturing test cases.
Replaced Keploy with the appropriate alias keploy as previously set.

**Issue number** : [#1134](https://github.com/keploy/keploy/issues/1134)