### PR TITLE
Updated Sidebar with "MUX + MongoDB"

### DIFF
--- a/src/components/GSoC.js
+++ b/src/components/GSoC.js
@@ -4,16 +4,16 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 export const GSoC = () => {
   return (
-    <section className="mt-1 mb-14">
+    <section className="mb-14 mt-1">
       <h2 className="text-3xl md:text-4xl">Keploy GSoC Guide</h2>
       <Link to={useBaseUrl("/gsoc/contribution-guide")}>
         <img
-          className="mt-5 w-full h-[450px]"
+          className="mt-5 h-[450px] w-full"
           src="/docs/img/gsoc-banner.png"
           alt={"GSoC 2023"}
         />
       </Link>
-      <div className="grid grid-cols-1 gap-6 mt-5 md:grid-cols-2 lg:gap-8">
+      <div className="mt-5 grid grid-cols-1 gap-6 md:grid-cols-2 lg:gap-8">
         <a
           className=" scale flex flex-col items-center justify-center space-y-3 rounded-lg bg-[color:orange] p-6 text-center shadow-lg"
           href="https://github.com/keploy/gsoc/tree/main/2023"

--- a/src/components/Hacktoberfest.js
+++ b/src/components/Hacktoberfest.js
@@ -4,8 +4,8 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 export const Hacktoberfest = () => {
   return (
-    <section className="mt-1 mb-14">
-      <h2 className="mt-8 text-2xl md:text-3xl font-semibold tracking-wide">
+    <section className="mb-14 mt-1">
+      <h2 className="mt-8 text-2xl font-semibold tracking-wide md:text-3xl">
         Keploy Hacktoberfest Guide
       </h2>
       <img
@@ -13,7 +13,7 @@ export const Hacktoberfest = () => {
         src="https://raw.githubusercontent.com/Sonichigo/crdb_keploy/main/Simple%20Technology%20Blog%20Banner%20(1).png?raw=true"
         alt={"hacktoberfest-2023"}
       />
-      <div className="grid grid-cols-1 gap-20 mt-10 md:grid-cols-2">
+      <div className="mt-10 grid grid-cols-1 gap-20 md:grid-cols-2">
         <a
           className=" scale flex flex-col items-center justify-center space-y-3 rounded-lg bg-[color:orange] p-4 text-center shadow-lg"
           href="https://github.com/keploy/keploy/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest2023"

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -141,7 +141,7 @@ function Server() {
 
 export const Intro = () => {
   return (
-    <section className="mt-1 mb-14">
+    <section className="mb-14 mt-1">
       <h2 className="mb-4 text-2xl font-semibold tracking-wide md:text-3xl">
         Supports
       </h2>

--- a/src/components/KeployCloud.js
+++ b/src/components/KeployCloud.js
@@ -4,7 +4,7 @@ export const KeployCloud = () => {
   return (
     <section
       id="cloud"
-      className="mt-24 mb-12 flex max-w-7xl items-center space-x-5 rounded-lg bg-[color:var(--ifm-card-background-color)] p-5"
+      className="mb-12 mt-24 flex max-w-7xl items-center space-x-5 rounded-lg bg-[color:var(--ifm-card-background-color)] p-5"
     >
       <svg
         className="h-12 w-12 flex-none "

--- a/src/components/QuickStart.js
+++ b/src/components/QuickStart.js
@@ -8,29 +8,29 @@ export const QuickStart = () => {
       <h1 className="mb-4 text-4xl font-semibold tracking-wide md:text-5xl">
         Welcome to Keploy Documentation! 🚀
       </h1>
-      <p className="max-w-3xl text-l">
+      <p className="text-l max-w-3xl">
         This documentation is your roadmap to becoming a Keploy expert, whether
         you're a seasoned developer or just starting out. 🗺️
       </p>
 
-      <h2 className="mb-4 text-2xl font-semibold tracking-wide md:text-3xl mt-8">
+      <h2 className="mb-4 mt-8 text-2xl font-semibold tracking-wide md:text-3xl">
         What is Keploy? 🤔
       </h2>
-      <p className="max-w-4xl text-l">
+      <p className="text-l max-w-4xl">
         Keploy is your open-source, developer-centric backend testing tool. It
         makes backend testing easy and productive for engineering teams. Plus,
         it's easy-to-use, powerful and extensible..🛠️
       </p>
-      <p className="max-w-4xl text-l mt-4">
+      <p className="text-l mt-4 max-w-4xl">
         Keploy creates test cases and data mocks/stubs from user-traffic by
         recording API calls and DB queries, significantly speeding up releases
         and enhancing reliability. 📈
       </p>
 
-      <h2 className="mt-8 text-2xl md:text-3xl font-semibold tracking-wide">
+      <h2 className="mt-8 text-2xl font-semibold tracking-wide md:text-3xl">
         Installation Guide 📗
       </h2>
-      <p className="max-w-4xl text-l mt-4 mb-8">
+      <p className="text-l mb-8 mt-4 max-w-4xl">
         Let's get Keploy up and running on your Windows, Linux, or macOS
         machine, so you can start crafting test cases in minutes. ⏱️
       </p>

--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -37,7 +37,7 @@ const links = [
 
 export const Resources = () => {
   return (
-    <section className="mt-12 mb-4">
+    <section className="mb-4 mt-12">
       <h2 className="mb-4 text-2xl font-semibold tracking-wide md:text-3xl">
         Quick Links
       </h2>

--- a/src/components/responsive-player/ResponsivePlayer.js
+++ b/src/components/responsive-player/ResponsivePlayer.js
@@ -9,7 +9,7 @@ function ResponsivePlayer({url, loop, playing}) {
     >
       {/* /* Player ratio: 100 / (1280 / 720) */}
       <ReactPlayer
-        className="absolute top-0 left-0"
+        className="absolute left-0 top-0"
         url={url}
         loop={loop}
         playing={playing}

--- a/src/pages/docs/reference/glossary.js
+++ b/src/pages/docs/reference/glossary.js
@@ -112,17 +112,17 @@ function Glossary() {
       description="User General Information about Keploy's Documentation"
     >
       <main className="margin-vert--lg container flex flex-col justify-evenly">
-        <div className="text-4xl font-bold text-center pb-5">Glossary</div>
+        <div className="pb-5 text-center font-bold text-4xl">Glossary</div>
         <div className="flex flex-row justify-evenly">
           {new Array(26).fill(0).map((x, i) => (
             <button
-              className={`col-span-1  p-3 rounded-sm gap-2
+              className={`col-span-1  gap-2 rounded-sm p-3
                     ${
                       state[String.fromCharCode(65 + i)]
-                        ? "text-black-200 hover:text-orange-950 font-bold bg-orange-200 rounded-3xl shadow-md"
+                        ? "text-black-200 rounded-3xl bg-orange-200 font-bold shadow-md hover:text-orange-950"
                         : entries[String.fromCharCode(65 + i)] === undefined
                         ? "bg-transparent text-gray-400" // Modified color class
-                        : "bg-grey-200 shadow-md rounded-3xl"
+                        : "bg-grey-200 rounded-3xl shadow-md"
                     } `}
               key={i}
               disabled={
@@ -136,13 +136,13 @@ function Glossary() {
             </button>
           ))}
         </div>
-        <div className="text-xl font-semibold mt-10 flex justify-center flex-wrap -mb-3 gap-4">
+        <div className="-mb-3 mt-10 flex flex-wrap justify-center gap-4 text-xl font-semibold">
           {Object.entries(state).map(([key, value]) => {
             return (
-              <div key={key} className="w-1/4 mb-4 col-span-3">
+              <div key={key} className="col-span-3 mb-4 w-1/4">
                 <div key={key}>{value ? key : ""}</div>
                 {value ? (
-                  <div className="text-l flex justify-around grid">
+                  <div className="text-l flex grid justify-around">
                     {entries[key]?.map(({name, link}, i) => (
                       <a
                         className="text-orange-600 hover:text-orange-950 hover:underline"

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -112,17 +112,17 @@ function Glossary() {
       description="User General Information about Keploy's Documentation"
     >
       <main className="margin-vert--lg container flex flex-col justify-evenly">
-        <div className="text-4xl font-bold text-center pb-5">Glossary</div>
+        <div className="pb-5 text-center font-bold text-4xl">Glossary</div>
         <div className="flex flex-row justify-evenly">
           {new Array(26).fill(0).map((x, i) => (
             <button
-              className={`col-span-1  p-3 rounded-sm gap-2
+              className={`col-span-1  gap-2 rounded-sm p-3
                     ${
                       state[String.fromCharCode(65 + i)]
-                        ? "text-black-200 hover:text-orange-950 font-bold bg-orange-200 rounded-3xl shadow-md"
+                        ? "text-black-200 rounded-3xl bg-orange-200 font-bold shadow-md hover:text-orange-950"
                         : entries[String.fromCharCode(65 + i)] === undefined
                         ? "bg-transparent text-gray-400" // Modified color class
-                        : "bg-grey-200 shadow-md rounded-3xl"
+                        : "bg-grey-200 rounded-3xl shadow-md"
                     } `}
               key={i}
               disabled={
@@ -136,13 +136,13 @@ function Glossary() {
             </button>
           ))}
         </div>
-        <div className="text-xl font-semibold mt-10 flex justify-center flex-wrap -mb-3 gap-4">
+        <div className="-mb-3 mt-10 flex flex-wrap justify-center gap-4 text-xl font-semibold">
           {Object.entries(state).map(([key, value]) => {
             return (
-              <div key={key} className="w-1/4 mb-4 col-span-3">
+              <div key={key} className="col-span-3 mb-4 w-1/4">
                 <div key={key}>{value ? key : ""}</div>
                 {value ? (
-                  <div className="text-l flex justify-around grid">
+                  <div className="text-l flex grid justify-around">
                     {entries[key]?.map(({name, link}, i) => (
                       <a
                         className="text-orange-600 hover:text-orange-950 hover:underline"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,7 +10,7 @@ export default function Home() {
   return (
     <div className="main">
       <Layout
-        className="my-2 mx-auto w-full max-w-screen-lg px-8 shadow-none"
+        className="mx-auto my-2 w-full max-w-screen-lg px-8 shadow-none"
         title={`${siteConfig.title}`}
         description={`${siteConfig.tagline}`}
       >

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -84,7 +84,7 @@ export default function DocItem(props) {
               <div
                 className={clsx(ThemeClassNames.docs.docMarkdown, "markdown")}
               >
-                <article className="md:prose-md prose mx-auto my-12 max-w-full px-2 md:px-6 lg:prose-lg">
+                <article className="md:prose-md prose mx-auto my-12 max-w-full px-2 lg:prose-lg md:px-6">
                   {/*
                 Title can be declared inside md content or declared through
                 front matter and added manually. To make both cases consistent,

--- a/versioned_docs/version-2.0.0/quickstart/go-mux-sql.md
+++ b/versioned_docs/version-2.0.0/quickstart/go-mux-sql.md
@@ -1,7 +1,7 @@
 ---
 id: samples-mux
 title: Sample Product Catalog App (Golang)
-sidebar_label: Mux + Postgres
+sidebar_label: MUX + MongoDB
 description: The following sample app showcases how to use Mux framework and the Keploy Platform.
 tags:
   - go


### PR DESCRIPTION
## Description

The side navbar of the [Mux and MongoDB sample app](https://keploy.io/docs/quickstart/samples-mux/) currently displays the name as "MUX+ Postgres," which is inaccurate. The correct representation should be "MUX + MongoDB." So I have updated the sidebar to accurately reflect the technologies used in the app.

Fixes #1402

## Type of Change

- [ x ] This change requires a documentation update.

## Checklist:

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have made corresponding changes to the documentation.

## Preview:
<img width="1100" alt="Screenshot 2024-01-25 at 1 24 57 AM" src="https://github.com/keploy/docs/assets/116814372/a8fdc31c-d226-4033-82e9-bd722291816b">

