### PR TITLE
feat: Added redirect link to Gittogether Banner Image

### DIFF
--- a/src/components/GitTogether.js
+++ b/src/components/GitTogether.js
@@ -8,11 +8,13 @@ export const GitTogether = () => {
       <h2 className="mt-8 text-2xl font-semibold tracking-wide md:text-3xl">
         Attend GitTogether
       </h2>
-      <img
-        className="mt-8 "
-        src="/docs/img/GitTogether.jpg"
-        alt={"GitTogether Image"}
-      />
+      <a href="https://keploy.io/gittogether">
+        <img
+          className="mt-8 "
+          src="/docs/img/GitTogether.jpg"
+          alt={"GitTogether Image"}
+        />
+      </a>
       <div className="mt-10 grid grid-cols-1 gap-20 md:grid-cols-2">
         <a
           className=" scale flex flex-col items-center justify-center space-y-3 rounded-lg border-2 border-[color:orange] p-4 text-center shadow-lg"


### PR DESCRIPTION
## Description:
This pull request adds a redirect link to the Gittogether Banner Image. When users click on the banner image, they will now be redirected to the designated URL.

## Changes Made:

- Added HTML anchor tag around the banner image.
- Specified the URL to redirect users to when clicking the banner.

## Testing:

- Tested the redirect functionality by clicking on the banner image in various browsers.
- Verified that users are correctly redirected to the specified URL.

