### PR TITLE
Update node-express-mongoose.md with missing command to run the examp…

### DIFF
--- a/versioned_docs/version-2.0.0/quickstart/node-express-mongoose.md
+++ b/versioned_docs/version-2.0.0/quickstart/node-express-mongoose.md
@@ -150,7 +150,13 @@ Depending on your OS, choose your adventure:
 
   #### 🍃 Kickstart MongoDB
 
-  Let's breathe life into your mongo container. A simple spell should do the trick:
+  We are going to run a mongo docker container which requires an existing docker network. We need to run the following command to create the required docker network:
+
+  ```bash
+  docker network create keploy-network
+  ```
+
+  Now, let's breathe life into your mongo container. A simple spell should do the trick:
 
   ```bash
   docker compose up mongo


### PR DESCRIPTION
We are missing a command to create the required docker network in the Linux instructions. This PR adds to the docs the info about the missing command.

Without this command, the following error is returned when running the command   ```docker compose up mongo ```

  ```Error response from daemon: network keploy-network not found  ```

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Followed the rest of the instructions to see if the whole Linux instructions were working as expected. The screenshot below shows the difference with the new command.

## Additional Context (Please include any Screenshots/gifs if relevant)

![image](https://github.com/keploy/docs/assets/32043860/187deacd-d6e1-43a5-9a2f-e9756ae5a174)
