### PR TITLE
Added env path in debugger

### DIFF
--- a/versioned_docs/version-2.0.0/keploy-explained/debugger-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/debugger-guide.md
@@ -44,12 +44,16 @@ Navigate to `launch.json` to begin crafting JSON objects.
       "asRoot": true,
       "console": "integratedTerminal",
       "program": "main.go",
-      "args": ["test", "-c", "<path_to_executable>"]
+      "args": ["test", "-c", "<path_to_executable>"],
+      "env": {
+        "PATH": "<path_to_Go_binary>"
+      }
     }
   ]
 }
 ```
 
+Path to go binary can be found via `echo $PATH`.
 Let's take a closer look at some important key-value pairs in our JSON file:
 
 - The `"name"` parameter can be anything, but for convenience, consider using the keploy command name (e.g., `Record` and `Test`).

--- a/versioned_docs/version-2.0.0/keploy-explained/debugger-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/debugger-guide.md
@@ -34,7 +34,10 @@ Navigate to `launch.json` to begin crafting JSON objects.
       "asRoot": true,
       "console": "integratedTerminal",
       "program": "main.go",
-      "args": ["record", "-c", "<path_to_executable>"]
+      "args": ["record", "-c", "<path_to_executable>"],
+      "env": {
+        "PATH": "<path_to_Go_binary>"
+      }
     },
     {
       "name": "Test",
@@ -53,7 +56,8 @@ Navigate to `launch.json` to begin crafting JSON objects.
 }
 ```
 
-Path to go binary can be found via `echo $PATH`.
+Path to Go binary can be found via `which go` for Linux and for MacOS `echo $PATH`.
+
 Let's take a closer look at some important key-value pairs in our JSON file:
 
 - The `"name"` parameter can be anything, but for convenience, consider using the keploy command name (e.g., `Record` and `Test`).


### PR DESCRIPTION
## Related Issue
- [docs]: adding env path in debugger
  - Issue: keploy/keploy#1574

#### Describe the changes you've made
Incorporating the addition of the "env" field in the debugger configuration to specify the path to the Go binary.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Please let us know if any test cases are added
NA

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
