### PR TITLE
feat: remove sys from import

### DIFF
--- a/versioned_docs/version-2.0.0/server/sdk-installation/python-sdk.md
+++ b/versioned_docs/version-2.0.0/server/sdk-installation/python-sdk.md
@@ -31,13 +31,12 @@ You can get the coverage with Keploy in 2 ways:
 First you need to install Keploy's Python SDK:
 
 ```bash
-pip install keploy
+pip install keploy pytest
 ```
 
 Next, create a test file for running Keploy's API tests. You can name the file `test_keploy.py`, and the contents of the file will be as follows:
 
 ```python
-import sys
 from keploy import run, RunOptions
 
 def test_keploy():


### PR DESCRIPTION
`import sys` is not required as well as how to install pytest wasn't mentioned anywhere in the guide, therefore have added `pip install keploy pytest`