### PR TITLE
Update `jsxBracketSameLine` to `bracketSameLine`

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,7 +4,7 @@
   "embeddedLanguageFormatting": "auto",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "jsxSingleQuote": false,
   "printWidth": 80,
   "proseWrap": "preserve",


### PR DESCRIPTION
# Pull Request Template

## Description

As discussed in Prettier's official blog https://prettier.io/blog/2021/09/09/2.4.0, I have removed the `jsxBracketSameLine` and added `bracketSameLine`.

Fixes https://github.com/keploy/keploy/issues/2092

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

1. Run `yarn prettier --write <path-to-file/filename>.md`
2. Doesn't generate any warning and performs check successfully.
![image](https://github.com/user-attachments/assets/a47309f9-cdd9-4e1e-9008-b98a16cb5721)


