### PR TITLE
fix: typo for no of modes

### DIFF
--- a/versioned_docs/version-2.0.0/keploy-explained/dev-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/dev-guide.md
@@ -41,7 +41,7 @@ It meticulously records API calls, database queries, and any other interactions 
 
 Once the recording phase is complete, Keploy can effortlessly generate test cases and data mocks in YAML format.
 
-#### Keploy operates in three modes:
+#### Keploy operates in two modes:
 
 - `record`: Capture Keploy test cases from API calls.
 - `test`: Execute recorded test cases and validate assertions.


### PR DESCRIPTION
## Description
In the docs, it was mentioned that Keploy has 3 modes, but it has only 2 as of now, `record` and `test`.

Fixes https://github.com/keploy/keploy/issues/2139

## Type of change

- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
