### PR TITLE
Fixed Docker tls assets download command

### DIFF
--- a/versioned_docs/version-2.0.0/running-keploy/docker-tls.md
+++ b/versioned_docs/version-2.0.0/running-keploy/docker-tls.md
@@ -27,8 +27,8 @@ keywords:
 
 ```dockerfile
 # Download the ca.crt file
-    RUN curl -o ca.crt  https://raw.githubusercontent.com/keploy/keploy/main/pkg/core/proxy/asset/ca.crt
-    RUN curl -o setup_ca.sh https://raw.githubusercontent.com/keploy/keploy/main/pkg/core/proxy/asset/setup_ca.sh
+    RUN curl -o ca.crt  https://raw.githubusercontent.com/keploy/keploy/refs/heads/main/pkg/core/proxy/tls/asset/ca.crt
+    RUN curl -o setup_ca.sh https://raw.githubusercontent.com/keploy/keploy/refs/heads/main/pkg/core/proxy/tls/asset/setup_ca.sh
     # Give execute permission to the setup_ca.sh script
     RUN chmod +x setup_ca.sh
 


### PR DESCRIPTION
## What has changed?

Docker TLS document has the wrong asset download URL.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.

<img width="646" alt="Screenshot 2024-10-27 at 8 37 50 PM" src="https://github.com/user-attachments/assets/1ba90c37-4e0e-4a9d-9651-e57ce1745a3c">

<img width="609" alt="Screenshot 2024-10-27 at 8 38 33 PM" src="https://github.com/user-attachments/assets/1a131498-5946-4c9f-9c41-cdb245234b72">


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->