### PR TITLE
Fix safari clipboard copy issue

### DIFF
--- a/src/components/Community.js
+++ b/src/components/Community.js
@@ -46,7 +46,8 @@ export const Community = () => {
           >
             <svg
               fill="currentColor"
-              className="h-12 w-12 flex-none text-red-500 "
+              // Hotfix: add viewBox to prevent icon from being cut off after tailwind preflight disabled
+              className="h-12 w-12 flex-none text-red-500 " viewBox="0 0  48 48"
             >
               <rect width="48" height="48" rx="12" />
               <path
@@ -94,7 +95,8 @@ export const Community = () => {
           >
             <svg
               fill="currentColor"
-              className="h-12 w-12 flex-none text-black "
+              // Hotfix: add viewBox to prevent icon from being cut off after tailwind preflight disabled
+              className="h-12 w-12 flex-none text-black "  viewBox="0 0  48 48"
             >
               <rect width="48" height="48" rx="12" />
               <path

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -316,6 +316,11 @@ footer svg {
   font-weight: 600;
 }
 
+/* Reset margin bottom on h3 (refer docs community section li item heading) after disabling tailwind preflight. */
+h3{
+  margin-bottom: 1px;
+}
+
 .related-read-link {
   margin-left: 7px;
 }
@@ -553,4 +558,145 @@ a[class="breadcrumbs__link"] {
 
 [data-theme="dark"] th {
   color: white;
+}
+
+/* Hotfix: Manually add Tailwind preflight styles to fix clipboard issues in Safari.
+   Using `preflight: true` caused style conflicts, so these styles are directly included here. */*,
+::before,
+::after {
+  box-sizing: border-box;
+  border-width: 0;
+  border-style: solid;
+  border-color: theme('borderColor.DEFAULT', currentColor);
+}
+
+* {
+  margin: 0;
+}
+
+html {
+  height: 100%;
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  -moz-tab-size: 4;
+  tab-size: 4;
+  font-family: theme('fontFamily.sans', ui-sans-serif, system-ui, sans-serif);
+}
+
+body {
+  height: 100%;
+  line-height: inherit;
+}
+
+img,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  vertical-align: middle;
+}
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+#root,
+#__next {
+  isolation: isolate;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+}
+
+:-moz-focusring {
+  outline: auto;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+:disabled {
+  cursor: default;
+}
+
+:focus-visible {
+  outline: 2px solid theme('colors.blue.600', #2563eb);
+  outline-offset: 2px;
+}
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+hr {
+  height: 0;
+  color: inherit;
+  border-top-width: 1px;
+}
+
+abbr:where([title]) {
+  text-decoration: underline dotted;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+textarea {
+  resize: vertical;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -321,6 +321,11 @@ h3{
   margin-bottom: 1px;
 }
 
+/* Reset any border-radius applied to images inside <td> elements. (see os icons and cross and tick icons in table) */
+td img {
+  border-radius: 0 !important;
+}
+
 .related-read-link {
   margin-left: 7px;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,7 +103,8 @@ module.exports = {
       },
       fontFamily: {
         light: ["Roboto Light", "sans"],
-        bold: ["Roboto Bold", "sans"],
+         /* Disable Roboto Bold to prevent fallback to Times font for highlighted text in the right article index sidebar and h3 elements on the homepage */
+        // bold: ["Roboto Bold", "sans"],
       },
       keyframes: {
         "fade-in-down": {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,11 +13,12 @@ module.exports = {
     "./src/pages/**/*.{js,ts,jsx,tsx}",
     "./src/theme/**/*.{js,ts,jsx,tsx}",
   ],
-  // corePlugins: {
-  //   // preflight: false, // to use Docusaurus base styles
-  //   // container: false, // use container style from docusaurus
-  // },
-  // // important: "#tailwind", // incrementally adopt Tailwind by wrapping pages with <div id="tailwind"> </div>
+  /* Hotfix: Disable Tailwind's preflight to resolve clipboard functionality issues in Safari */
+  corePlugins: {
+    preflight: false, // to use Docusaurus base styles
+    // container: false, // use container style from docusaurus
+  },
+  // important: "#tailwind", // incrementally adopt Tailwind by wrapping pages with <div id="tailwind"> </div>
   theme: {
     extend: {
       typography: {


### PR DESCRIPTION
## What has changed?
This PR includes the following changes:
- Fixed Safari clipboard issue by disabling Tailwind preflight.
- Added Tailwind preflight styles manually in custom.css.
- Fixed icon scaling issues caused by disabling preflight.
- Reset border-radius for images in table cells and disabled Roboto Bold to prevent font fallback issues.

## Please include a summary of the change.
This PR fixes clipboard copy issue on safari and fixes few styling issues.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?
- Ran `npm run build` and `npm run serve` to verify the changes.
- Checked clipboard functionality in Safari.
- Verified proper rendering of images and icons.




## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->