### PR TITLE
feat: fix screen responsiveness

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -212,13 +212,26 @@ div[class^="sidebar_"] .button svg {
 
 /* Pagination */
 .pagination-nav {
-  @apply flex flex-col items-start justify-center space-x-0 space-y-5 md:flex-row md:space-x-10 md:space-y-0;
+  @apply flex flex-row items-center justify-between space-x-5;
 }
 .pagination-nav__item {
-  @apply w-full max-w-md;
+  @apply flex-grow;
 }
 .pagination-nav__link {
-  @apply flex-grow transform rounded-lg border-0 bg-[color:var(--ifm-card-background-color)] p-5  text-lg shadow-lg transition-transform hover:scale-105;
+  @apply flex flex-col items-center justify-center rounded-lg border-0 bg-[color:var(--ifm-card-background-color)] p-5  text-lg shadow-lg overflow-hidden transition-transform hover:scale-105;
+  width: 100%;
+  max-width: 48%;
+  text-align: center;
+}
+
+/*proactively styling for the button text here*/
+
+.pagination-nav_link span:frst-child{
+  @apply text-sm font-bold mb-1;/*smaller, bold font for previous or next*/
+}
+
+.pagination-nav_link span:last-child{
+  @apply text-base text-ellipsis whitespace-nowrap overflow-hidden;
 }
 
 /* Navbar */


### PR DESCRIPTION
## What has changed?
Responsiveness issues in the documentation page

Please include a summary of the change:
This PR resolves the responsiveness issues with the "Previous" and "Next" buttons on the documentation page. The buttons are now fully responsive across all devices, maintaining their alignment and functionality on different screen sizes.

Also, proactively styled the button text in order to avoid future failure in responsiveness.

On large screen sizes:

<img width="548" alt="Screenshot 2025-02-10 144127" src="https://github.com/user-attachments/assets/7228b85a-b434-46a8-96f2-804dab0dd9b5" />

On smaller screen sizes:

<img width="159" alt="Screenshot 2025-02-10 174606" src="https://github.com/user-attachments/assets/aa18373e-16f0-4499-8074-d012677daff3" />


This PR Resolves #489

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested? Yes.

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.

Output of both Commands:

<img width="251" alt="Screenshot 2025-02-10 174234" src="https://github.com/user-attachments/assets/47df81bd-0b5b-4792-995b-ec22fcd0c34b" />

<img width="314" alt="Screenshot 2025-02-10 174023" src="https://github.com/user-attachments/assets/39f90e45-b590-4108-96c0-f2a07a1b75f3" />



## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.



