### PR TITLE
docs: update the karaf links

### DIFF
--- a/versioned_docs/version-2.0.0/running-keploy/keploy-karaf.md
+++ b/versioned_docs/version-2.0.0/running-keploy/keploy-karaf.md
@@ -12,17 +12,23 @@ keywords:
   - running-guide
 ---
 
-## Step 1: Download Required JARs
+## Step 1: Download Required JARs and Keploy Version
+
+Use Keploy's One click to install latest keploy binary -
+
+```bash
+  curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
+```
 
 Use `wget` to download the necessary JAR files:
 
-- [KeployAgent.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/KeployAgent.jar)
+- [io.keploy.agent-2.0.1.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar)
 - [org.jacoco.agent-0.8.12-runtime.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
 
 Run the following commands to download the files:
 
 ```bash
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/KeployAgent.jar
+wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar
 wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
 ```
 


### PR DESCRIPTION
## What has changed?

This pull request includes a change to the `versioned_docs/version-2.0.0/running-keploy/keploy-karaf.md` file to update the instructions for downloading required JARs and the Keploy version. 

The most important changes include:

* Updated the step title to include downloading the Keploy version.
* Added a command to install the latest Keploy binary using a one-click script.
* Changed the JAR file name from `KeployAgent.jar` to `io.keploy.agent-2.0.1.jar` in both the download link and the `wget` command.

This PR Resolves #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->