### PR TITLE
Making the icons in the docs page of Keploy to behave the same way on hover

### DIFF
--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -37,7 +37,7 @@ function Languages() {
             to={useBaseUrl("/quickstart/samples-gin")}
           >
             <img
-              className="h-8 w-8"
+              className="h-8 w-8 transition hover:scale-110"
               src="/docs/img/golang.svg"
               alt="Go lang logo"
             />
@@ -63,7 +63,7 @@ function Languages() {
             to={useBaseUrl("/quickstart/samples-django")}
           >
             <img
-              className="h-8 w-8"
+              className="h-8 w-8 transition hover:scale-110"
               src="/docs/img/python.svg"
               alt="Python logo"
             />
@@ -142,7 +142,7 @@ function Frameworks() {
             className="flex flex-col items-center justify-center space-y-1 p-6 text-center hover:underline"
           >
             <img
-              className="h-8 w-8"
+              className="h-8 w-8 transition hover:scale-110"
               src="/docs/img/mongodb-logo.svg"
               alt="Docker logo"
             />
@@ -155,7 +155,7 @@ function Frameworks() {
             className="flex flex-col items-center justify-center space-y-1 p-6 text-center hover:underline"
           >
             <img
-              className="h-8 w-8"
+              className="h-8 w-8 transition hover:scale-110"
               src="/docs/img/http-logo.svg"
               alt="HTTP logo"
             />
@@ -168,7 +168,7 @@ function Frameworks() {
             className="flex flex-col items-center justify-center space-y-1 p-6 text-center hover:underline"
           >
             <img
-              className="h-8 w-8"
+              className="h-8 w-8 transition hover:scale-110"
               src="/docs/img/postgres-logo.svg"
               alt="PostgresSQL logo"
             />
@@ -178,10 +178,10 @@ function Frameworks() {
         <li className="mt-5 flex flex-col space-y-3 text-lg">
           <Link
             to={useBaseUrl("/dependencies/redis")}
-            className="flex flex-col items-center justify-center space-y-1 p-6 text-center "
+            className="flex flex-col items-center justify-center space-y-1 p-6 text-center hover:underline"
           >
             <img
-              className="h-8 w-8"
+              className="h-8 w-8 transition hover:scale-110"
               src="/docs/img/redis-logo.svg"
               alt="Redis logo"
             />


### PR DESCRIPTION
## What has changed?

The icons in the docs page of Keploy do not hover the same way in the 'Languages' and the 'Dependencies Support' sections. This PR fixes that issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Made the changes and ran the server locally to make sure the changes are expected. Attaching a screen recording below for more clarity regarding the PR

https://github.com/user-attachments/assets/58cdca24-786e-458f-8973-7fa400cf263f


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->