### PR TITLE
docs: remove the wrong --coverage flag, update dev guide to include r…

### DIFF
--- a/versioned_docs/version-2.0.0/keploy-explained/dev-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/dev-guide.md
@@ -71,15 +71,7 @@ After entering record mode, send requests to your application to generate test c
 ```shell
 go run -exec "sudo -E env 'PATH=$PATH'" -tags=viper_bind_struct main.go test -c "path/to/go/binary/of/application" --delay 10
 ```
-
-Run Keploy server to expose test APIs:
-
-```shell
-go run -exec "sudo -E env 'PATH=$PATH'" -tags=viper_bind_struct main.go test -c "path/to/go/binary/of/application" --delay 10 --coverage
-```
-
-Generated test cases can be found inside the Keploy directory.
-
+Generated test cases can be found inside the Keploy directory. Generated reports can be found under the reports directory inside Keploy directory. 
 ### 5. Setup Keploy using Binary:
 
 #### Generate Keploy Binary:


### PR DESCRIPTION
## What has changed?
The contributing guide contained a wrong flag in one of the command example, `--coverage` . Removed the same and have added documentation on information about the reports generated via the `test` command
![image](https://github.com/user-attachments/assets/e6582732-ed78-4099-9893-9aa90e6c196c)

## Type of change

- [x] Documentation update

## How Has This Been Tested?
![image](https://github.com/user-attachments/assets/39899f9b-acf7-4ea9-8cef-3070292aaa16)

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->