### PR TITLE
Improve Glossary Page: fixed typo, now stubs has valid link attribute

### DIFF
--- a/src/pages/concepts/reference/glossary.js
+++ b/src/pages/concepts/reference/glossary.js
@@ -105,7 +105,7 @@ function Glossary() {
     S: [
       {
         name: "Stubs",
-        ink: "/docs/concepts/reference/glossary/stubs",
+        link: "/docs/concepts/reference/glossary/stubs",
       },
       {
         name: "Software Testing Life Cycle",


### PR DESCRIPTION
## What has changed?

Fixed a typo in the Glossary page entries object. Now "stubs" in the S key has a valid link attribute. 

This PR Resolves no known issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.
Screenshot of the output of both commands:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/3bb2db94-6e14-4beb-9313-3800dbfd1ac6" />
Gif of user clicking on stubs link.
![test](https://github.com/user-attachments/assets/15469212-ad26-4667-b566-6cde0954dc20)


<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->