### PR TITLE
typo error , fixed ink to link

### DIFF
--- a/src/pages/concepts/reference/glossary.js
+++ b/src/pages/concepts/reference/glossary.js
@@ -105,7 +105,7 @@ function Glossary() {
     S: [
       {
         name: "Stubs",
-        ink: "/docs/concepts/reference/glossary/stubs",
+        link: "/docs/concepts/reference/glossary/stubs",
       },
       {
         name: "Software Testing Life Cycle",


### PR DESCRIPTION
## What has changed?

Fixed the type error in glossary.js file - from ink to link
