### PR TITLE
fix: correct typo in write-heading-ids script and add development scr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "format": "prettier --write .",
-    "prepare": "husky install",
-    "lint": "eslint . --ext .js,.jsx",
-    "lint:fix": "eslint . --ext .js,.jsx --fix",
-    "check-format": "prettier --check .",
-    "validate": "npm run check-format && npm run lint && npm run build"
+    "prepare": "husky install"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
hanged "wnrite-heading-ids" → "write-heading-ids"
This was a simple typo that would have caused the script to fail