### PR TITLE
Updated the sidebar component to allow only one section to expand at a time

### DIFF
--- a/versioned_sidebars/version-3.0.0-sidebars.json
+++ b/versioned_sidebars/version-3.0.0-sidebars.json
@@ -3,7 +3,8 @@
     {
       "type": "category",
       "label": "Unit Testing",
-      "collapsed": false,
+      "collapsed": true,
+      "collapsible": true,
       "items": [
         "running-keploy/about-unit-testing",
         {
@@ -31,7 +32,8 @@
     {
       "type": "category",
       "label": "Integration Testing",
-      "collapsed": false,
+      "collapsed": true,
+      "collapsible": true,
       "items": [
         {
           "type": "category",
@@ -178,7 +180,8 @@
     {
       "type": "category",
       "label": "API Testing",
-      "collapsed": false,
+      "collapsed": true,
+      "collapsible": true,
       "items": [
         "running-keploy/about-api-testing",
         "running-keploy/api-test-generator",
@@ -215,6 +218,7 @@
       "type": "category",
       "label": "Contribute",
       "collapsible": true,
+      "collapsed": true,
       "items": [
         "keploy-explained/contribution-guide",
         "keploy-explained/docs-dev-guide",


### PR DESCRIPTION
## What has changed?

Fixed an issue in the Keploy Docs sidebar where clicking on any tab in the navbar resulted in all sidebar tabs expanding simultaneously. The sidebar now maintains a cleaner UX by allowing only one tab to be open at a time. 

This PR resolves #2785
https://github.com/keploy/keploy/issues/2785

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## How Has This Been Tested?

- Ran `npm run build` to ensure build passes without errors.
- Ran `npm run serve` to manually test sidebar interaction behavior.
- Sidebar now collapses previously open tabs when a new one is expanded.

### Screenshots:

| Before | After |
|--------|-------|
| ![After](https://github.com/user-attachments/assets/8e064fee-371d-4ee7-8db8-2275b757b227) | ![Before](https://github.com/user-attachments/assets/c51a1c10-a0a3-4602-8deb-378982917f64) | 


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] UI is responsive and maintains usability across devices.
- [x] I have tested the changes thoroughly using the development build.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
