### PR TITLE
fix: removed old contact us page

### DIFF
--- a/src/components/KeployCloud.js
+++ b/src/components/KeployCloud.js
@@ -4,7 +4,7 @@ export const KeployCloud = () => {
   return (
     <section
       id="cloud"
-      className="mb-12 mt-24 flex max-w-7xl items-center space-x-5 rounded-lg bg-[color:var(--ifm-card-background-color)] p-5"
+      className="mt-8 flex max-w-7xl items-center space-x-5 rounded-lg bg-[color:var(--ifm-card-background-color)] p-5"
     >
       <div className="prose prose-orange mx-auto max-w-3xl">
         <h1> Question? 🤔💭</h1>

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -19,6 +19,7 @@ import DocBreadcrumbs from "@theme/DocBreadcrumbs";
 import Layout from "@docusaurus/core/lib/client/theme-fallback/Layout";
 import Head from "@docusaurus/Head";
 import MDXContent from "@theme/MDXContent";
+import {KeployCloud} from "@site/src/components/KeployCloud";
 
 export default function DocItem(props) {
   const {content: DocContent} = props;
@@ -105,7 +106,9 @@ export default function DocItem(props) {
                 </article>
               </div>
             </article>
-
+            <div>
+              <KeployCloud />
+            </div>
             <DocPaginator previous={metadata.previous} next={metadata.next} />
           </div>
         </div>

--- a/versioned_docs/version-2.0.0/ci-cd/github.md
+++ b/versioned_docs/version-2.0.0/ci-cd/github.md
@@ -216,7 +216,3 @@ sudo -E keploy test -c node src/app.js --delay 10 --path ./
 _And... voila! You have successfully integrated keploy in GitHub CI pipeline 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-2.0.0/ci-cd/gitlab.md
@@ -148,7 +148,3 @@ Integrating Keploy with GitLab CI automates the testing process, ensuring that t
 If you’re thinking, “This pipeline looks cool, but I need the _whole thing_ to integrate with your application!” — well, you're in luck! Check it out [here](https://github.com/keploy/samples-python) and get ready to copy-paste your way to success! ✨🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-2.0.0/ci-cd/jenkins.md
@@ -173,7 +173,3 @@ Testrun passed for testcase with id: "test-2"
 _And... voila! You have successfully integrated keploy in Jenkins CI/CD pipeline 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/concepts/what-are-keploy-features.md
+++ b/versioned_docs/version-2.0.0/concepts/what-are-keploy-features.md
@@ -92,7 +92,3 @@ As the application serves the API, Keploy re-run that API request with the captu
 Keploy identifies differences in API responses, marking them as random/noisy fields. 🧐✅
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/concepts/what-is-a-keploy-ebpf.md
+++ b/versioned_docs/version-2.0.0/concepts/what-is-a-keploy-ebpf.md
@@ -27,7 +27,3 @@ Comparing the expected and actual responses for an API call happens at the Keplo
 A Keploy eBPF mocks the external dependencies while testing APIs, eliminating the need to setup test-environment. This allows the application to isolate itself from external dependencies.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/concepts/what-is-keploy.md
+++ b/versioned_docs/version-2.0.0/concepts/what-is-keploy.md
@@ -60,7 +60,3 @@ You can test with Keploy locally or can integrate Keploy with popular testing-fr
 > **Note:** You can generate test cases from any environment which has all the infrastructure dependencies setup. Please consider using this to generate tests from low-traffic environments first. The deduplication feature necessary for high-traffic environments is currently experimental.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/dependencies/http.md
+++ b/versioned_docs/version-2.0.0/dependencies/http.md
@@ -42,7 +42,3 @@ So in the record mode, the encode function is provided with the initial request,
 Next, if the request contains the expect header or not. The expect header is used by a client when sending very large requests. So it is basically used to ask the server if it is ready to accept such a large req or not, if it is, then the server responds with a `"100-continue"` response. This is what we also check by writing the request to the destination connection and reading the response from it. We start reading the response and we handle chunking in that case as well. Then finally, keploy parse the request and response to store it in mocks.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/dependencies/mongo.md
+++ b/versioned_docs/version-2.0.0/dependencies/mongo.md
@@ -56,7 +56,3 @@ OP_MSG {
 - In version 4.2, MongoDB removes the deprecated internal `OP_COMMAND` and `OP_COMMANDREPLY` protocol.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/dependencies/postgresql.md
+++ b/versioned_docs/version-2.0.0/dependencies/postgresql.md
@@ -71,7 +71,3 @@ type RegularPacket struct {
 ```
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/dependencies/redis.md
+++ b/versioned_docs/version-2.0.0/dependencies/redis.md
@@ -33,7 +33,3 @@ In test mode, the decode function is activated. Its role is to match incoming re
 The test mode process starts with the `MockOutgoing` function, which reads the initial request from the client. The request is then decoded using the `decodeRedis` function. This function reads the request stream, attempts to match the request with existing mocks using a fuzzy matching algorithm, and retrieves the corresponding responses. If a match is found, the responses are decoded and written back to the client.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/common-errors.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/common-errors.md
@@ -194,7 +194,3 @@ Keploy does not support the protocol or API structure you are using (e.g., gRPC,
 - Consider alternative tools or frameworks for unsupported protocols.
 
 If you’re still encountering issues after trying these solutions, feel free to reach out to the Keploy team or consult the community forums for additional support. Happy testing!
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/debugger-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/debugger-guide.md
@@ -99,7 +99,3 @@ You can either add more objects in the "configurations" array or modify the "arg
 Click the **Start Debugging** button to witness the magic of debugging unfold seamlessly.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/dev-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/dev-guide.md
@@ -163,7 +163,3 @@ There you have it! With this guide, you're all set to dive into Keploy developme
 > **Note** :- Run `go run github.com/99designs/gqlgen generate --config pkg/graph/gqlgen.yml` to generate the graphql server stubs which can be used when working with unit testing libraries like JUnit, PyTest, etc..
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/docs-dev-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/docs-dev-guide.md
@@ -165,7 +165,3 @@ If you have ideas on how we can improve, please share them with us by creating a
 Right now our interfaces do not support translations and we also don't have a translation strategy in place. But we want to change this. We want our projects to be accessible to non-English speakers. If you have any ideas then please share them with us by creating a [new issue].
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/faq.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/faq.md
@@ -61,7 +61,3 @@ Yes, Keploy is open-source and free to use under the Apache 2.0 license. You can
 Yes, Keploy provides configuration options to customize recording, replay, and comparison logic for specific APIs, giving users control over how their APIs are tested.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/how-keploy-works.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/how-keploy-works.md
@@ -57,7 +57,3 @@ Consider an application server serving HTTP APIs for clients like web/mobile app
 - **Test Mode:** Keploy reads the YAML files for test cases and stubs/mocks. It starts the application, sends recorded HTTP test cases, and mocks responses for outgoing calls. This ensures no side effects due to non-idempotency.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/testing-guide.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/testing-guide.md
@@ -144,7 +144,3 @@ If both scenarios yield a "passed" result, it signifies that this approach mirro
 <!-- To understand the internals you can refer to this [blog](blog link). -->
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/keploy-explained/why-keploy.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/why-keploy.md
@@ -29,7 +29,3 @@ tags:
 ⭐ If you're excited about what's coming, show some love by [starring Keploy on GitHub](https://github.com/keploy/keploy)
 
 🤙 We're happy to hear from you in-case you want to deep-dive. [Schedule a demo](https://calendar.app.google/3mHeyaoKg3A2qkqF6) – because the best tests are yet to come! 🚀🎉
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/csharp-dotnet-postgres.md
+++ b/versioned_docs/version-2.0.0/quickstart/csharp-dotnet-postgres.md
@@ -174,7 +174,3 @@ Congrats on the journey so far! You've seen Keploy's power, flexed your coding m
 Happy coding! ✨👩‍💻👨‍💻✨
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/go-fasthttp-postgres.md
+++ b/versioned_docs/version-2.0.0/quickstart/go-fasthttp-postgres.md
@@ -277,7 +277,3 @@ Congrats on the journey so far! You've seen Keploy's power, flexed your coding m
 Happy coding! ✨👩‍💻👨‍💻✨
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/go-gin-redis.md
+++ b/versioned_docs/version-2.0.0/quickstart/go-gin-redis.md
@@ -431,7 +431,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/go-mux-mysql.md
+++ b/versioned_docs/version-2.0.0/quickstart/go-mux-mysql.md
@@ -221,7 +221,3 @@ We will get output something like this:
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/go-mux-sql.md
+++ b/versioned_docs/version-2.0.0/quickstart/go-mux-sql.md
@@ -386,7 +386,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/java-spring-boot-mongo.md
+++ b/versioned_docs/version-2.0.0/quickstart/java-spring-boot-mongo.md
@@ -165,7 +165,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/java-spring-boot-openhospital.md
+++ b/versioned_docs/version-2.0.0/quickstart/java-spring-boot-openhospital.md
@@ -114,7 +114,3 @@ Here `delay` is the time it takes for your application to get started, after whi
 `buildDelay` is the time that it takes for the image to get built. This is useful when you are building the docker image from your docker compose file itself.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/java-spring-boot-xml.md
+++ b/versioned_docs/version-2.0.0/quickstart/java-spring-boot-xml.md
@@ -163,7 +163,3 @@ After updating `keploy.yml` with the above configuration, rerun your tests, and 
 ## Wrapping Up 🎉
 
 Fantastic! You've successfully navigated creating and testing XML APIs with Spring Boot and Keploy. Keep exploring, experimenting, and innovating! If you have any queries, we're here to help!
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/java-spring-postgres.md
+++ b/versioned_docs/version-2.0.0/quickstart/java-spring-postgres.md
@@ -150,7 +150,3 @@ Here `delay` is the time it takes for your application to get started, after whi
 `buildDelay` is the time that it takes for the image to get built. This is useful when you are building the docker image from your docker compose file itself.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/nextjs-postgres.md
+++ b/versioned_docs/version-2.0.0/quickstart/nextjs-postgres.md
@@ -107,7 +107,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/node-express-mongoose.md
+++ b/versioned_docs/version-2.0.0/quickstart/node-express-mongoose.md
@@ -214,7 +214,3 @@ Worry not, just add the ever-changing fields (like our **ts** here) to the **noi
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/node-jwt-sql.md
+++ b/versioned_docs/version-2.0.0/quickstart/node-jwt-sql.md
@@ -337,9 +337,3 @@ Now, let's run the keploy in test mode again:-
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>
-
-**\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\_\_\_\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\***

--- a/versioned_docs/version-2.0.0/quickstart/python-django-sql.md
+++ b/versioned_docs/version-2.0.0/quickstart/python-django-sql.md
@@ -462,7 +462,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/python-fastapi-sql.md
+++ b/versioned_docs/version-2.0.0/quickstart/python-fastapi-sql.md
@@ -395,7 +395,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/python-fastapi-twilio.md
+++ b/versioned_docs/version-2.0.0/quickstart/python-fastapi-twilio.md
@@ -448,7 +448,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the Twilio response 
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/python-flask-mongo.md
+++ b/versioned_docs/version-2.0.0/quickstart/python-flask-mongo.md
@@ -389,7 +389,3 @@ python3 -m coverage html
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/rust-wrap-mongo.md
+++ b/versioned_docs/version-2.0.0/quickstart/rust-wrap-mongo.md
@@ -100,7 +100,3 @@ sudo -E env PATH=$PATH keploy test -c 'cargo run'
 _Voila!! Our testcases has passed 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/sample-ts.md
+++ b/versioned_docs/version-2.0.0/quickstart/sample-ts.md
@@ -278,7 +278,3 @@ You've successfully tested the tool and created your mocks and test cases—fant
 Here’s to building more, innovating, and reaching new heights with your project! 🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/samples-bunjs.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-bunjs.md
@@ -382,7 +382,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/samples-echo.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-echo.md
@@ -228,7 +228,3 @@ We will get output something like this:
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/samples-go-gin-mongo.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-go-gin-mongo.md
@@ -400,7 +400,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/samples-java.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-java.md
@@ -300,7 +300,3 @@ Here’s how to set it up with GitHub Actions:
 👉 [Keploy + GitHub CI/CD Guide](https://keploy.io/docs/ci-cd/github)
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/samples-node-mongo.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-node-mongo.md
@@ -261,7 +261,3 @@ npm run coverage
 Congratulations! You've conquered Keploy and unleashed its power for effortless testing in your NodeJS application. With Jest by your side, you can ensure rock-solid code coverage. Time to go forth and build amazing things! 🧑🏻‍💻
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-2.0.0/quickstart/samples-rust.md
+++ b/versioned_docs/version-2.0.0/quickstart/samples-rust.md
@@ -70,7 +70,3 @@ sudo -E env PATH=$PATH keploy test -c 'cargo run'
 _Voila!! Our testcases has passed 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/ci-cd/github.md
+++ b/versioned_docs/version-3.0.0/ci-cd/github.md
@@ -216,7 +216,3 @@ sudo -E keploy test -c node src/app.js --delay 10 --path ./
 _And... voila! You have successfully integrated keploy in GitHub CI pipeline 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-3.0.0/ci-cd/gitlab.md
@@ -148,7 +148,3 @@ Integrating Keploy with GitLab CI automates the testing process, ensuring that t
 If you’re thinking, “This pipeline looks cool, but I need the _whole thing_ to integrate with your application!” — well, you're in luck! Check it out [here](https://github.com/keploy/samples-python) and get ready to copy-paste your way to success! ✨🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-3.0.0/ci-cd/jenkins.md
@@ -173,7 +173,3 @@ Testrun passed for testcase with id: "test-2"
 _And... voila! You have successfully integrated keploy in Jenkins CI/CD pipeline 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/concepts/what-are-keploy-features.md
+++ b/versioned_docs/version-3.0.0/concepts/what-are-keploy-features.md
@@ -92,7 +92,3 @@ As the application serves the API, Keploy re-run that API request with the captu
 Keploy identifies differences in API responses, marking them as random/noisy fields. 🧐✅
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/concepts/what-is-a-keploy-ebpf.md
+++ b/versioned_docs/version-3.0.0/concepts/what-is-a-keploy-ebpf.md
@@ -27,7 +27,3 @@ Comparing the expected and actual responses for an API call happens at the Keplo
 A Keploy eBPF mocks the external dependencies while testing APIs, eliminating the need to setup test-environment. This allows the application to isolate itself from external dependencies.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/concepts/what-is-keploy.md
+++ b/versioned_docs/version-3.0.0/concepts/what-is-keploy.md
@@ -59,8 +59,4 @@ You can test with Keploy locally or can integrate Keploy with popular testing-fr
 
 > **Note:** You can generate test cases from any environment which has all the infrastructure dependencies setup. Please consider using this to generate tests from low-traffic environments first. The deduplication feature necessary for high-traffic environments is currently experimental.
 
-Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>
+Hope this helps you out, if you still have any questions, reach out to us.

--- a/versioned_docs/version-3.0.0/dependencies/http.md
+++ b/versioned_docs/version-3.0.0/dependencies/http.md
@@ -42,7 +42,3 @@ So in the record mode, the encode function is provided with the initial request,
 Next, if the request contains the expect header or not. The expect header is used by a client when sending very large requests. So it is basically used to ask the server if it is ready to accept such a large req or not, if it is, then the server responds with a `"100-continue"` response. This is what we also check by writing the request to the destination connection and reading the response from it. We start reading the response and we handle chunking in that case as well. Then finally, keploy parse the request and response to store it in mocks.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/dependencies/mongo.md
+++ b/versioned_docs/version-3.0.0/dependencies/mongo.md
@@ -56,7 +56,3 @@ OP_MSG {
 - In version 4.2, MongoDB removes the deprecated internal `OP_COMMAND` and `OP_COMMANDREPLY` protocol.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/dependencies/postgresql.md
+++ b/versioned_docs/version-3.0.0/dependencies/postgresql.md
@@ -71,7 +71,3 @@ type RegularPacket struct {
 ```
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/dependencies/redis.md
+++ b/versioned_docs/version-3.0.0/dependencies/redis.md
@@ -33,7 +33,3 @@ In test mode, the decode function is activated. Its role is to match incoming re
 The test mode process starts with the `MockOutgoing` function, which reads the initial request from the client. The request is then decoded using the `decodeRedis` function. This function reads the request stream, attempts to match the request with existing mocks using a fuzzy matching algorithm, and retrieves the corresponding responses. If a match is found, the responses are decoded and written back to the client.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/api-testing-faq.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/api-testing-faq.md
@@ -102,7 +102,3 @@ Have questions or need a security report for your team? [Contact us!](mailto:sup
 Your code, your data, your control. 🔐
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/common-errors.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/common-errors.md
@@ -194,7 +194,3 @@ Keploy does not support the protocol or API structure you are using (e.g., gRPC,
 - Consider alternative tools or frameworks for unsupported protocols.
 
 If you’re still encountering issues after trying these solutions, feel free to reach out to the Keploy team or consult the community forums for additional support. Happy testing!
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/debugger-guide.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/debugger-guide.md
@@ -99,7 +99,3 @@ You can either add more objects in the "configurations" array or modify the "arg
 Click the **Start Debugging** button to witness the magic of debugging unfold seamlessly.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/dev-guide.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/dev-guide.md
@@ -163,7 +163,3 @@ There you have it! With this guide, you're all set to dive into Keploy developme
 > **Note** :- Run `go run github.com/99designs/gqlgen generate --config pkg/graph/gqlgen.yml` to generate the graphql server stubs which can be used when working with unit testing libraries like JUnit, PyTest, etc..
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/docs-dev-guide.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/docs-dev-guide.md
@@ -164,8 +164,4 @@ If you have ideas on how we can improve, please share them with us by creating a
 
 Right now our interfaces do not support translations and we also don't have a translation strategy in place. But we want to change this. We want our projects to be accessible to non-English speakers. If you have any ideas then please share them with us by creating a [new issue].
 
-Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>
+Hope this helps you out, if you still have any questions, reach out to us

--- a/versioned_docs/version-3.0.0/keploy-explained/how-keploy-works.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/how-keploy-works.md
@@ -57,7 +57,3 @@ Consider an application server serving HTTP APIs for clients like web/mobile app
 - **Test Mode:** Keploy reads the YAML files for test cases and stubs/mocks. It starts the application, sends recorded HTTP test cases, and mocks responses for outgoing calls. This ensures no side effects due to non-idempotency.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/integration-testing-faq.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/integration-testing-faq.md
@@ -63,7 +63,3 @@ Yes, Keploy is open-source and free to use under the Apache 2.0 license. You can
 Yes, Keploy provides configuration options to customize recording, replay, and comparison logic for specific APIs, giving users control over how their APIs are tested.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/testing-guide.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/testing-guide.md
@@ -144,7 +144,3 @@ If both scenarios yield a "passed" result, it signifies that this approach mirro
 <!-- To understand the internals you can refer to this [blog](blog link). -->
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/unit-testing-faq.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/unit-testing-faq.md
@@ -102,7 +102,3 @@ We’re committed to keeping your trust.
 - Deeper IDE and CI/CD integrations
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/utg-best-practices.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/utg-best-practices.md
@@ -277,7 +277,3 @@ Seamlessly blend test generation with existing development practices:
 - **Continuous Learning**: Stay updated with testing industry best practices
 
 _Remember: Automated testing tools are force multipliers, not replacements for thoughtful testing strategy. The goal is to amplify human expertise, not replace human judgment._
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/keploy-explained/why-keploy.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/why-keploy.md
@@ -29,7 +29,3 @@ tags:
 ⭐ If you're excited about what's coming, show some love by [starring Keploy on GitHub](https://github.com/keploy/keploy)
 
 🤙 We're happy to hear from you in-case you want to deep-dive. [Schedule a demo](https://calendar.app.google/3mHeyaoKg3A2qkqF6) – because the best tests are yet to come! 🚀🎉
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/csharp-dotnet-postgres.md
+++ b/versioned_docs/version-3.0.0/quickstart/csharp-dotnet-postgres.md
@@ -174,7 +174,3 @@ Congrats on the journey so far! You've seen Keploy's power, flexed your coding m
 Happy coding! ✨👩‍💻👨‍💻✨
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/go-fasthttp-postgres.md
+++ b/versioned_docs/version-3.0.0/quickstart/go-fasthttp-postgres.md
@@ -277,7 +277,3 @@ Congrats on the journey so far! You've seen Keploy's power, flexed your coding m
 Happy coding! ✨👩‍💻👨‍💻✨
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/go-gin-redis.md
+++ b/versioned_docs/version-3.0.0/quickstart/go-gin-redis.md
@@ -431,7 +431,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/go-mux-mysql.md
+++ b/versioned_docs/version-3.0.0/quickstart/go-mux-mysql.md
@@ -221,7 +221,3 @@ We will get output something like this:
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/go-mux-sql.md
+++ b/versioned_docs/version-3.0.0/quickstart/go-mux-sql.md
@@ -386,7 +386,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/java-spring-boot-mongo.md
+++ b/versioned_docs/version-3.0.0/quickstart/java-spring-boot-mongo.md
@@ -165,7 +165,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/java-spring-boot-openhospital.md
+++ b/versioned_docs/version-3.0.0/quickstart/java-spring-boot-openhospital.md
@@ -114,7 +114,3 @@ Here `delay` is the time it takes for your application to get started, after whi
 `buildDelay` is the time that it takes for the image to get built. This is useful when you are building the docker image from your docker compose file itself.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/java-spring-boot-xml.md
+++ b/versioned_docs/version-3.0.0/quickstart/java-spring-boot-xml.md
@@ -163,7 +163,3 @@ After updating `keploy.yml` with the above configuration, rerun your tests, and 
 ## Wrapping Up 🎉
 
 Fantastic! You've successfully navigated creating and testing XML APIs with Spring Boot and Keploy. Keep exploring, experimenting, and innovating! If you have any queries, we're here to help!
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/java-spring-postgres.md
+++ b/versioned_docs/version-3.0.0/quickstart/java-spring-postgres.md
@@ -149,7 +149,3 @@ Here `delay` is the time it takes for your application to get started, after whi
 `buildDelay` is the time that it takes for the image to get built. This is useful when you are building the docker image from your docker compose file itself.
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/nextjs-postgres.md
+++ b/versioned_docs/version-3.0.0/quickstart/nextjs-postgres.md
@@ -107,7 +107,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/node-express-mongoose.md
+++ b/versioned_docs/version-3.0.0/quickstart/node-express-mongoose.md
@@ -214,7 +214,3 @@ Worry not, just add the ever-changing fields (like our **ts** here) to the **noi
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/node-jwt-sql.md
+++ b/versioned_docs/version-3.0.0/quickstart/node-jwt-sql.md
@@ -337,9 +337,3 @@ Now, let's run the keploy in test mode again:-
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>
-
-**\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\_\_\_\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\*\*\***\*\*\***

--- a/versioned_docs/version-3.0.0/quickstart/python-django-sql.md
+++ b/versioned_docs/version-3.0.0/quickstart/python-django-sql.md
@@ -462,7 +462,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/python-fastapi-sql.md
+++ b/versioned_docs/version-3.0.0/quickstart/python-fastapi-sql.md
@@ -395,7 +395,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/python-fastapi-twilio.md
+++ b/versioned_docs/version-3.0.0/quickstart/python-fastapi-twilio.md
@@ -448,7 +448,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the Twilio response 
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/python-flask-mongo.md
+++ b/versioned_docs/version-3.0.0/quickstart/python-flask-mongo.md
@@ -389,7 +389,3 @@ python3 -m coverage html
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/rust-wrap-mongo.md
+++ b/versioned_docs/version-3.0.0/quickstart/rust-wrap-mongo.md
@@ -101,7 +101,3 @@ sudo -E env PATH=$PATH keploy test -c 'cargo run'
 _Voila!! Our testcases has passed 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/sample-ts.md
+++ b/versioned_docs/version-3.0.0/quickstart/sample-ts.md
@@ -278,7 +278,3 @@ You've successfully tested the tool and created your mocks and test cases—fant
 Here’s to building more, innovating, and reaching new heights with your project! 🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/samples-bunjs.md
+++ b/versioned_docs/version-3.0.0/quickstart/samples-bunjs.md
@@ -382,7 +382,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/samples-echo.md
+++ b/versioned_docs/version-3.0.0/quickstart/samples-echo.md
@@ -228,7 +228,3 @@ We will get output something like this:
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/samples-go-gin-mongo.md
+++ b/versioned_docs/version-3.0.0/quickstart/samples-go-gin-mongo.md
@@ -400,7 +400,3 @@ Final thoughts? Dive deeper! Try different API calls, tweak the DB response in t
 Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible. 😊🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/samples-java.md
+++ b/versioned_docs/version-3.0.0/quickstart/samples-java.md
@@ -300,7 +300,3 @@ Here’s how to set it up with GitHub Actions:
 👉 [Keploy + GitHub CI/CD Guide](https://keploy.io/docs/ci-cd/github)
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/samples-node-mongo.md
+++ b/versioned_docs/version-3.0.0/quickstart/samples-node-mongo.md
@@ -261,7 +261,3 @@ npm run coverage
 Congratulations! You've conquered Keploy and unleashed its power for effortless testing in your NodeJS application. With Jest by your side, you can ensure rock-solid code coverage. Time to go forth and build amazing things! 🧑🏻‍💻
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/quickstart/samples-rust.md
+++ b/versioned_docs/version-3.0.0/quickstart/samples-rust.md
@@ -70,7 +70,3 @@ sudo -E env PATH=$PATH keploy test -c 'cargo run'
 _Voila!! Our testcases has passed 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/running-keploy/api-testing-cicd.md
+++ b/versioned_docs/version-3.0.0/running-keploy/api-testing-cicd.md
@@ -92,7 +92,3 @@ Failed suites:      0
 ## That's it!
 
 With just a few lines of YAML, you’ve added **AI-powered API test automation** into your GitHub CI pipeline. Now every PR or deployment will be automatically tested with Keploy’s smart test engine.
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/running-keploy/utg-pr-agent.md
+++ b/versioned_docs/version-3.0.0/running-keploy/utg-pr-agent.md
@@ -89,7 +89,3 @@ Ready to transform your pull request workflow from a potential quality bottlenec
 3. **Experience the difference** in your next code review cycle
 
 _Elevate your development workflow. Make every pull request a quality checkpoint._
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>

--- a/versioned_docs/version-3.0.0/running-keploy/utg-vsc-extension.md
+++ b/versioned_docs/version-3.0.0/running-keploy/utg-vsc-extension.md
@@ -125,7 +125,3 @@ Don't let testing slow down your development velocity. With Keploy's AI-powered 
 4. **Watch your test coverage soar** while maintaining development speed
 
 _Transform your IDE. Elevate your code quality. Join 500k+ developers building better software with Keploy._
-
-import GetSupport from '../concepts/support.md'
-
-<GetSupport/>


### PR DESCRIPTION
## What has changed?

I have removed the Old contact us page and added new contact us page

**Before:**
<img width="873" alt="Screenshot 2025-07-08 at 5 20 19 PM" src="https://github.com/user-attachments/assets/8ac1fd29-5518-40b8-9e65-b3597bfef080" />


**After:**
<img width="965" alt="Screenshot 2025-07-08 at 5 20 50 PM" src="https://github.com/user-attachments/assets/5f556545-b0f7-47c8-80ab-48232ece82b6" />


This PR Resolves #(issue)

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).
- [x] Documentation update (if none of the other choices apply).



## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.