### PR TITLE
fix: the-broken-link-of-glossary

### DIFF
--- a/versioned_docs/version-2.0.0/concepts/reference/glossary/black-box-testing.md
+++ b/versioned_docs/version-2.0.0/concepts/reference/glossary/black-box-testing.md
@@ -25,7 +25,7 @@ Black-box testing is a software testing method where the tester evaluates the fu
 
 The focus lies solely on examining the software's external behavior, inputs, outputs, and responses to different user actions or system interactions.
 
-![types of testing](../../../../../static/img/glossary/types-of-testing.jpeg)
+![Types of Testing](https://keploy-devrel.s3.us-west-2.amazonaws.com/types-of-testing.jpeg)
 
 ## What are the Fundamentals of Black-Box Testing?
 

--- a/versioned_docs/version-2.0.0/concepts/reference/glossary/code-coverage.md
+++ b/versioned_docs/version-2.0.0/concepts/reference/glossary/code-coverage.md
@@ -41,7 +41,7 @@ It's analysis provides several benefits:
 
 Keploy has native integrations with your unit-testing libraries like go-test, jUnit, jest, pyTest. Keploy gives combined test-coverage and can also be integrated in existing CI pipelines easily within go-test, jUnit, jest, pyTest workflows.
 
-<img scr="https://keploy.io/docs/gif/replay-tc.gif?raw=true"/>
+![Keploy Test Replay](https://keploy.io/docs/gif/replay-tc.gif)
 
 By generating additional tests that exercise different parts of your codebase, you can increase the percentage of code that is covered by your tests. For example, in case of NodeJS application you can use Jest. Jest provides a built-in code coverage tool that can help you measure the effectiveness of your tests and identify areas of the code that need additional testing. By adding Keploy SDK with Jest, you can easily generate test cases and increase your code coverage. Let's create a `Keploy.test.js`
 

--- a/versioned_docs/version-2.0.0/concepts/reference/glossary/white-box-testing.md
+++ b/versioned_docs/version-2.0.0/concepts/reference/glossary/white-box-testing.md
@@ -28,7 +28,7 @@ White box testing, also known as clear box or glass box testing, is a software t
 
 The primary goal of white box testing is to validate the software's internal operations, ensuring that it functions correctly and efficiently. This involves checking all pathways and conditions, optimizing code for speed and performance, and ensuring that there are no hidden errors.
 
-![types of testing](../../../../../static/img/glossary/types-of-testing.jpeg)
+![Types of Testing](https://keploy-devrel.s3.us-west-2.amazonaws.com/types-of-testing.jpeg)
 
 ## Fundamentals of White Box Testing
 

--- a/versioned_docs/version-3.0.0/concepts/reference/glossary/white-box-testing.md
+++ b/versioned_docs/version-3.0.0/concepts/reference/glossary/white-box-testing.md
@@ -28,7 +28,7 @@ White box testing, also known as clear box or glass box testing, is a software t
 
 The primary goal of white box testing is to validate the software's internal operations, ensuring that it functions correctly and efficiently. This involves checking all pathways and conditions, optimizing code for speed and performance, and ensuring that there are no hidden errors.
 
-![types of testing](../../../../../static/img/glossary/types-of-testing.jpeg)
+![Types of Testing](https://keploy-devrel.s3.us-west-2.amazonaws.com/types-of-testing.jpeg)
 
 ## Fundamentals of White Box Testing
 


### PR DESCRIPTION
**Fix: Corrected broken link in glossary**
This pull request resolves an issue with a broken link within the documentation's glossary section.