### PR TITLE
fix: flask-mongo quickstart local mongo setup

### DIFF
--- a/versioned_docs/version-3.0.0/quickstart/python-flask-mongo.md
+++ b/versioned_docs/version-3.0.0/quickstart/python-flask-mongo.md
@@ -214,11 +214,13 @@ We'll be running our sample application right on Linux, but just to make things 
 pip install -r requirements.txt
 ```
 
-## Start the MongoDB server
+## Start the MongoDB container
 
 ```bash
-sudo service mongod start
+docker run -p 27017:27017 -d --network backend --name mongo mongo
 ```
+
+> **Since we are using a MongoDB container, we need to update the `client` on line 11 in `app.py`, to `localhost`.**
 
 ## Lights, Camera, Record! 🎥
 


### PR DESCRIPTION
## What has changed?

I have fixed the Flask MongoDB quickstart guide for the local setup. Previously, the guide was incorrect, but I have updated it to run MongoDB as a container.


This PR Resolves #(issue)

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?
<img width="1054" height="351" alt="Screenshot 2025-07-30 at 5 27 09 PM" src="https://github.com/user-attachments/assets/145c9c0e-194d-4526-962a-d6777136d3a0" />

**Current Issue:**
<img width="808" height="539" alt="Screenshot 2025-07-30 at 5 28 49 PM" src="https://github.com/user-attachments/assets/277555a5-9c6b-44ab-9fe6-dda8d82327ea" />


**Solution:**
<img width="900" height="658" alt="Screenshot 2025-07-30 at 5 28 16 PM" src="https://github.com/user-attachments/assets/9cc51886-6970-490e-bc69-d798131c3d3f" />


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
