### PR TITLE
fix: correct the docs version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ MinAlertLevel = error
 
 ### Running Vale
 
-1. Linting Documentation: To check all markdown files in versioned_docs/version-2.0.0/ for errors, run:
+1. Linting Documentation: To check all markdown files in versioned_docs/version-3.0.0/ for errors, run:
 
 ```bash
-vale versioned_docs/version-2.0.0/**/*.md
+vale versioned_docs/version-3.0.0/**/*.md
 ```
 
 2. Review Errors:

--- a/versioned_docs/version-3.0.0/running-keploy/generate-api-tests-using-ai.md
+++ b/versioned_docs/version-3.0.0/running-keploy/generate-api-tests-using-ai.md
@@ -7,7 +7,7 @@ description: Learn how to use Keploy’s API Test Generator to generate high-qua
 
 This guide will help you generate automated API tests using Keploy's AI-based test engine by providing structured inputs like OpenAPI specs, curl commands, Postman collections, or live endpoints.
 
-> 👉 If you want to record API flows by interacting with your web app through a browser, follow this guide instead: Record API Tests via Chrome Extension
+> 👉 If you want to record API flows by interacting with your web app through a browser, follow this guide instead: [Record API Tests via Chrome Extension](https://keploy.io/docs/running-keploy/api-testing-chrome-extension/)
 
 ## Getting Started
 

--- a/versioned_docs/version-3.0.0/running-keploy/review-and-improve-ai-generated-tests.md
+++ b/versioned_docs/version-3.0.0/running-keploy/review-and-improve-ai-generated-tests.md
@@ -70,7 +70,7 @@ Mix-and-match them as needed—every example below can live inside the same `ass
 | **Header Exists**     | Header key is present (value ignored).                 | `yaml<br>- type: header_exists<br>  field: x-request-id<br>`                                               | Reverse-proxy injects `x-request-id: 4b087…`                                 |
 | **Header Matches**    | Header value matches a **regex** pattern.              | `yaml<br>- type: header_matches<br>  field: set-cookie<br>  pattern: "sessionId=.*; Path=/; HttpOnly"<br>` | `set-cookie: sessionId=abc123; Path=/; HttpOnly; SameSite=Lax`               |
 
-> **Tip **  
+> **Tip**  
 > Combine multiple assertions in one step to cover status, headers **and** body in a single round-trip. Every assertion is evaluated independently, so one failure pinpoints the exact mismatch.
 
 ## Edit and Manage Test Suites


### PR DESCRIPTION
## PR Description

### 📝 Fix: Update Documentation Version References in README

**What changed:**
- Updated the documentation version reference in README.md from `version-2.0.0` to `version-3.0.0`
- Fixed the Vale linting command examples to point to the correct documentation version directory

**Why this change was needed:**
This fix ensures that the README instructions are accurate and point to the current documentation version. Users following the linting documentation instructions will now reference the correct versioned directory structure.

**Files changed:**
- `README.md` - Updated Vale command examples from `versioned_docs/version-2.0.0/` to `versioned_docs/version-3.0.0/`

**Type of change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

**Testing:**
- Verified that the updated paths in the README match the actual documentation directory structure
- Commands in the README now reference the correct version directory
<img width="802" height="527" alt="Screenshot From 2025-08-11 13-24-19" src="https://github.com/user-attachments/assets/777e9215-c68c-4813-8ee7-ea70ac356f5e" />


This is a minor but important fix to keep the documentation accurate and prevent confusion for contributors who follow the README instructions for linting documentation.