### PR TITLE
docs: add Keploy API Testing to Quick Links (#2925)

### DIFF
--- a/src/components/Resources.js
+++ b/src/components/Resources.js
@@ -33,6 +33,12 @@ const links = [
     length: "2 min watch",
     url: "https://www.youtube.com/watch?v=23yQaY81Zho",
   },
+  {
+    type:"video",
+    length:"1 min watch",
+    title:" AI Powered API testing",
+    url:"https://www.youtube.com/watch?v=W6kh-TCUQH0"
+  }
 ];
 
 export const Resources = () => {


### PR DESCRIPTION
docs: add Keploy API Testing to Documentation Quick Links (#2925)

- Added a new quick link entry in /src/resource.js:
  {
    type: "video",
    length: "1 min watch",
    title: "AI Powered API testing",
    url: "https://www.youtube.com/watch?v=W6kh-TCUQH0"
  }

- Ensured style matches the existing Integration Testing link
- Verified the new link appears correctly in Documentation Quick Links
<img width="960" height="540" alt="keploy" src="https://github.com/user-attachments/assets/6b5c9dc9-fd49-4fe6-91ad-08ecb9aace87" />
