### PR TITLE
docs: removed the lines that caused repitition in docs-dev-guide

### DIFF
--- a/versioned_docs/version-3.0.0/keploy-explained/docs-dev-guide.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/docs-dev-guide.md
@@ -40,12 +40,6 @@ npm start
 or
 
 ```shell
-npm start
-```
-
-or
-
-```shell
 yarn start
 ```
 


### PR DESCRIPTION
## What has changed?

This PR omits the repitition of npm start shell command from the docs dev guide page.

Resolves [#2773](https://github.com/keploy/keploy/issues/2773)

## Type of change

- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

- [x] output of npm run build
<img width="552" height="449" alt="Screenshot From 2025-09-01 23-56-16" src="https://github.com/user-attachments/assets/0609f387-8fba-42e7-ad31-691189416c90" />

- [x] output of npm run serve
<img width="553" height="134" alt="Screenshot From 2025-09-01 23-58-08" src="https://github.com/user-attachments/assets/86a760c0-fca5-41d4-81e9-0461e6ad0b14" />

- [x] screenshot of the change 
<img width="1914" height="966" alt="Screenshot From 2025-09-01 23-57-42" src="https://github.com/user-attachments/assets/c4930e01-d031-42d5-894e-d8c7a24392ba" />

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.