### PR TITLE
added space between search and theme toggler

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -229,6 +229,7 @@ div[class^="sidebar_"] .button svg {
 
 .navbar__items--right {
   @apply justify-end ml-auto flex-row-reverse;
+  gap: 12px;
 }
 
 .navbar__items--right > :last-child {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -229,7 +229,7 @@ div[class^="sidebar_"] .button svg {
 
 .navbar__items--right {
   @apply justify-end ml-auto flex-row-reverse;
-  gap: 12px;
+  gap: 13px;
 }
 
 .navbar__items--right > :last-child {


### PR DESCRIPTION
## What has changed?

Added space in the website between the search and them toggler

This PR Resolves https://github.com/keploy/keploy/issues/2943 #2943

## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.
<img width="1136" height="440" alt="image" src="https://github.com/user-attachments/assets/8a8a1907-4c05-44b4-bdd4-787d25be0878" />
<img width="1723" height="890" alt="image" src="https://github.com/user-attachments/assets/de3406db-293a-494b-96f3-5bd02e93d9a3" />


## Checklist:

- [*] My code follows the style guidelines of this project.
- [*] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->