### PR TITLE
Increasesd spacing between the search bar and dark mode icon

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -229,6 +229,7 @@ div[class^="sidebar_"] .button svg {
 
 .navbar__items--right {
   @apply justify-end ml-auto flex-row-reverse;
+  gap: 13px;
 }
 
 .navbar__items--right > :last-child {


### PR DESCRIPTION
## What has changed?

Increased spacing between dark mode icon and the search bar.

This PR Resolves [#2943](https://github.com/keploy/keploy/issues/2943)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

- [x] npm run build
<img width="629" height="483" alt="header-spacing-build" src="https://github.com/user-attachments/assets/7ad310bb-9007-4874-8756-4c7a2e2234d3" />

- [x] npm run serve
<img width="629" height="143" alt="header-spacing-serve" src="https://github.com/user-attachments/assets/bb59da38-48ff-4cc1-a9e7-040ac8e53908" />

- [x] change
<img width="517" height="66" alt="header-spacing" src="https://github.com/user-attachments/assets/e88d2d3d-9cac-482d-8c20-7d4458261a70" />

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->