### PR TITLE
docs: Add documentation for 'keploy contract' command

### DIFF
--- a/docs/running-keploy/cli-commands/contract.md
+++ b/docs/running-keploy/cli-commands/contract.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 7
+---
+
+# Keploy Contract Command
+
+The `keploy contract` command is used for managing and generating contract tests from existing test cases. It helps in identifying breaking API contract changes by generating data-driven tests based on OpenAPI/Swagger specifications.
+
+## Usage
+
+```bash
+keploy contract <sub-command> [flags]


### PR DESCRIPTION
This pull request adds a new documentation page for the `keploy contract` command.

The new page explains the purpose of the command, details its `generate` sub-command, and provides a clear example for users.

Addresses keploy/keploy#2969