### PR TITLE
feat(docs): Update scroll-to-top icon color for visibility

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -744,4 +744,17 @@ textarea {
   resize: vertical;
 }
 
+.theme-back-to-top-button {
+  background-color: #FF914D !important;
+  color: white !important;
+}
+
+.theme-back-to-top-button svg {
+  fill: white !important;
+}
+
+.theme-back-to-top-button:hover {
+  background-color: #e67643 !important;
+}
+
 


### PR DESCRIPTION
## What has changed?

Fixed the back-to-top button visibility issue by updating its styling in `custom.css`. The button was previously white and barely visible against light backgrounds, making it difficult for users to find and use. 

Updated the `.theme-back-to-top-button` CSS class to use Keploy's orange theme color (#FF914D) for the background with white icon/text for proper contrast. Added hover effects for better user experience.

This PR Resolves #3004

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).


## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.

**Testing Steps:**
1. Navigate to any docs page
2. Scroll down until the back-to-top button appears
3. Verify the button is now orange (#FF914D) with white icon
4. Test hover effect (darker orange #e67643)
5. Click button to ensure scroll-to-top functionality works

**Screenshots:**

**Before:**
<img width="1990" height="246" alt="image" src="https://github.com/user-attachments/assets/a4673e0d-19b7-4fd3-904d-9d25f1e7eaf4" />


**After:**
<img width="1812" height="148" alt="kep1" src="https://github.com/user-attachments/assets/b5e2d3ac-38f1-4f06-a92a-2575e74b33cd" />
<img width="127" height="108" alt="kep2" src="https://github.com/user-attachments/assets/ba382f02-2deb-4fc8-af3f-ed1510475253" />


**Build Output:**
✓ Client
  Compiled successfully in 45.90s

**Serve Output:**
[SUCCESS] Serving "build" directory at: http://localhost:3000/docs/

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

**Technical Notes:**
- Used `!important` declarations to override Docusaurus default styles (acceptable for third-party framework overrides)
- Component-specific styling isolated to back-to-top button only
- Maintains theme consistency with Keploy's orange color scheme
- Added proper contrast with white icon/text on orange background

Closes #3004