### PR TITLE
Fix:Updated NodeVersion In Github Actions for docs 

### DIFF
--- a/.github/workflows/build_and_check.yml
+++ b/.github/workflows/build_and_check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
## What has changed?

Updated GitHub Actions workflow for the Docs website CI/CD pipeline.

Bumped Node.js version from 18 to 20 (or higher) using actions/setup-node.

This PR Resolves [#3055](https://github.com/keploy/keploy/issues/3055)

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue).


## How Has This Been Tested?

<img width="820" height="332" alt="image" src="https://github.com/user-attachments/assets/0f32b049-d6f2-427d-83f0-54d69a9fe919" />


## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->