### PR TITLE
fix(docs): Update Node.js version to 22.x in docs CI (#3055)

### DIFF
--- a/.github/workflows/build_and_check.yml
+++ b/.github/workflows/build_and_check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 18.0.0
+          node-version: 22.20.0
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
## What has changed?
This PR updates the GitHub Actions workflow file (`.github/workflows/build_and_check.yml`) for the Docs website CI/CD pipeline.
The Node.js version in the setup step has been updated from `18.x` (or `18.0.0`) to `22.x` (the latest Node.js LTS line).

This PR Resolves #(issue)
This change fixes the pipeline failures caused by the build process requiring a newer Node.js version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

I have tested this change locally by performing a successful build of the documentation website using the updated Node version.
1.  `npm install`
2.  `npm run build`
<img width="1458" height="682" alt="Screenshot 2025-09-27 120911" src="https://github.com/user-attachments/assets/585027ed-f6f5-45b1-87eb-865a832d537c" />
<img width="1302" height="669" alt="Screenshot 2025-09-27 120925" src="https://github.com/user-attachments/assets/7ba246a5-b590-4417-b36f-15a16dabca69" />



## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->