### PR TITLE
Feature: Added "Back To Top Button" in Glossary Page

### DIFF
--- a/src/pages/concepts/reference/glossary.js
+++ b/src/pages/concepts/reference/glossary.js
@@ -1,5 +1,6 @@
 import React, {useState, useMemo} from "react";
 import Layout from "@theme/Layout";
+import BackToTopButton from "@theme/BackToTopButton";
 
 import {glossaryEntries} from "../../../../static/data/glossaryEntries";
 import GlossaryCard from "../../../components/GlossaryCard";
@@ -127,6 +128,7 @@ function Glossary() {
             </div>
           )}
         </div>
+        <BackToTopButton />
       </main>
     </Layout>
   );


### PR DESCRIPTION
## What has changed?
This PR adds a "scroll-to-top" button to the Glossary page.

Previously, the Glossary page lacked this navigation feature, which is already present on other long-form content pages. This created an inconsistent user experience, requiring users to scroll manually to the top of a potentially long page.

This change utilizes the existing BackToTop component to ensure functional and visual consistency with the rest of the documentation site, improving overall usability.

This PR Resolves [#3086](https://github.com/keploy/keploy/issues/3086)
## Type of change

- [X] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

***Build Results***
<img width="1073" height="275" alt="image" src="https://github.com/user-attachments/assets/b142f3c1-cec4-4d38-b28c-f69cb0dab8b9" />


## Screenshot

<img width="1919" height="921" alt="image" src="https://github.com/user-attachments/assets/fe1e5da0-84db-4f2e-8fd7-669eca8c664d" />



## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->