### PR TITLE
feat: add back-to-top button to glossary page

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,19 +12,19 @@
 
 :root {
   /* Hotfix: Changed primary color to black to resolve conflict with Docusaurus' default primary orange after disabling Tailwind preflight CSS. Added font size and line height adjustments to compensate for the removal of Tailwind preflight. */
- 
+
   /* --ifm-color-primary-lighter: #ffb575; */
-  font-size:18px;
+  font-size: 18px;
   line-height: 1.6;
   --ifm-color-primary: #000;
 
-  --ifm-color-primary-lighter: #FFF;
+  --ifm-color-primary-lighter: #fff;
   --ifm-color-primary: #ff914d;
   --ifm-color-primary-dark: #e67643;
   --ifm-color-primary-darker: #c95919;
   --ifm-color-primary-darkest: #be2c1b;
   --ifm-color-primary-light: #ffd0a0;
-  
+
   --ifm-color-primary-lightest: #ffceb1;
   --ifm-code-font-size: 95%;
   --doc-sidebar-width: 275px !important;
@@ -37,11 +37,10 @@
 
 html[data-theme="dark"] {
   /* Hotfix: Changed 'ifm-color-primary-lighter' to white to resolve conflict with Docusaurus' default color after disabling Tailwind preflight CSS. */
-  
 
   /* --ifm-color-primary-lighter: #ffb575; */
-  --ifm-color-primary-lighter: #FFF; 
-   
+  --ifm-color-primary-lighter: #fff;
+
   --ifm-color-primary: #ff914d;
   --ifm-color-primary-dark: #e67643;
   --ifm-color-primary-darker: #c95919;
@@ -112,7 +111,7 @@ html[data-theme="light"] {
 }
 
 /* Hotfix: Remove extra margin-bottom on community links subtext in the home page due to Tailwind preflight removal */
-h3{
+h3 {
   margin-bottom: 0.1rem;
 }
 h1,
@@ -213,7 +212,7 @@ div[class^="sidebar_"] .button svg {
 
 /* Pagination */
 .pagination-nav {
-  @apply flex mt-12 flex-col items-start justify-center space-x-0 space-y-5 md:flex-row md:space-x-10 md:space-y-0;
+  @apply mt-12 flex flex-col items-start justify-center space-x-0 space-y-5 md:flex-row md:space-x-10 md:space-y-0;
 }
 .pagination-nav__item {
   @apply w-full max-w-md;
@@ -228,7 +227,7 @@ div[class^="sidebar_"] .button svg {
 }
 
 .navbar__items--right {
-  @apply justify-end ml-auto flex-row-reverse;
+  @apply ml-auto flex-row-reverse justify-end;
   gap: 13px;
 }
 
@@ -336,7 +335,7 @@ footer svg {
 }
 
 /* Reset margin bottom on h3 (refer docs community section li item heading) after disabling tailwind preflight. */
-h3{
+h3 {
   margin-bottom: 1px;
 }
 
@@ -604,13 +603,14 @@ a[class="breadcrumbs__link"] {
 }
 
 /* Hotfix: Manually add Tailwind preflight styles to fix clipboard issues in Safari.
-   Using `preflight: true` caused style conflicts, so these styles are directly included here. */*,
+   Using `preflight: true` caused style conflicts, so these styles are directly included here. */
+*,
 ::before,
 ::after {
   box-sizing: border-box;
   border-width: 0;
   border-style: solid;
-  border-color: theme('borderColor.DEFAULT', currentColor);
+  border-color: theme("borderColor.DEFAULT", currentColor);
 }
 
 * {
@@ -623,7 +623,7 @@ html {
   -webkit-text-size-adjust: 100%;
   -moz-tab-size: 4;
   tab-size: 4;
-  font-family: theme('fontFamily.sans', ui-sans-serif, system-ui, sans-serif);
+  font-family: theme("fontFamily.sans", ui-sans-serif, system-ui, sans-serif);
 }
 
 body {
@@ -677,9 +677,9 @@ html {
 }
 
 button,
-[type='button'],
-[type='reset'],
-[type='submit'] {
+[type="button"],
+[type="reset"],
+[type="submit"] {
   -webkit-appearance: button;
   background-color: transparent;
   background-image: none;
@@ -706,12 +706,12 @@ menu {
 }
 
 :focus-visible {
-  outline: 2px solid theme('colors.blue.600', #2563eb);
+  outline: 2px solid theme("colors.blue.600", #2563eb);
   outline-offset: 2px;
 }
 
-[type='number']::-webkit-inner-spin-button,
-[type='number']::-webkit-outer-spin-button {
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -745,7 +745,7 @@ textarea {
 }
 
 .theme-back-to-top-button {
-  background-color: #FF914D !important;
+  background-color: #ff914d !important;
   color: white !important;
 }
 
@@ -756,5 +756,3 @@ textarea {
 .theme-back-to-top-button:hover {
   background-color: #e67643 !important;
 }
-
-

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -763,7 +763,6 @@ textarea {
   resize: vertical;
 }
 
-/* TODO: Define --ifm-color-accent in your theme CSS if not already present */
 :root {
   --ifm-color-accent: #f1ccb1;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,7 +12,6 @@
 
 :root {
   /* Hotfix: Changed primary color to black to resolve conflict with Docusaurus' default primary orange after disabling Tailwind preflight CSS. Added font size and line height adjustments to compensate for the removal of Tailwind preflight. */
-
   /* --ifm-color-primary-lighter: #ffb575; */
   font-size: 18px;
   line-height: 1.6;
@@ -31,7 +30,8 @@
   --ifm-link-hover-decoration: none;
   --ifm-link-hover-color: inherit;
   --site-primary-hue-saturation: 30 100%;
-  --site-primary-hue-saturation-light: 0 0%; /* do we really need this extra one? */
+  --site-primary-hue-saturation-light: 0 0%;
+  /* do we really need this extra one? */
   --slack-logo: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1610 1610'%3E%3Cpath fill='%23E01E5A' d='M338 1017c0 93-76 169-169 169S0 1110 0 1017s76-169 169-169h169v169zM423 1017c0-93 76-169 169-169s169 76 169 169v424c0 93-76 169-169 169s-169-76-169-169v-424z'/%3E%3Cpath fill='%2336C5F0' d='M593 338c-93 0-169-76-169-169S500 0 593 0s169 76 169 169v169H593zM593 423c93 0 169 76 169 169s-76 169-169 169H169C76 761 0 685 0 592s76-169 169-169h424z'/%3E%3Cpath fill='%232EB67D' d='M1272 593c0-93 76-169 169-169s169 76 169 169-76 169-169 169h-169V593zM1187 593c0 93-76 169-169 169s-169-76-169-169V169C849 76 925 0 1018 0s169 76 169 169v424z'/%3E%3Cpath fill='%23ECB22E' d='M1017 1272c93 0 169 76 169 169s-76 169-169 169-169-76-169-169v-169h169zM1017 1187c-93 0-169-76-169-169s76-169 169-169h424c93 0 169 76 169 169s-76 169-169 169h-424z'/%3E%3C/svg%3E");
 }
 
@@ -75,7 +75,8 @@ html[data-theme="light"] {
   --ifm-badge-background-color: rgba(239, 246, 255);
 
   --card-color: rgba(239, 246, 255);
-  --ifm-card-shadow-color: rgba(0, 0, 0, 0.2); /* Dark shadow for light theme */
+  --ifm-card-shadow-color: rgba(0, 0, 0, 0.2);
+  /* Dark shadow for light theme */
 }
 
 @font-face {
@@ -114,6 +115,7 @@ html[data-theme="light"] {
 h3 {
   margin-bottom: 0.1rem;
 }
+
 h1,
 h2,
 h3,
@@ -134,6 +136,7 @@ h4,
 .menu__list-item > .menu__link > span {
   display: flex;
 }
+
 .menu__link--sublist:after {
   background: var(--ifm-menu-link-sublist-icon) 50% / 1.5rem 1.5rem;
 }
@@ -146,6 +149,7 @@ div[class^="sidebar_"]
 div[class^="sidebar_"] .button {
   @apply mx-auto mb-2 w-full border-0;
 }
+
 div[class^="sidebar_"] .button svg {
   @apply mx-auto;
 }
@@ -157,6 +161,7 @@ div[class^="sidebar_"] .button svg {
 .table-of-contents__link {
   @apply text-sm text-[color:var(--ifm-color)];
 }
+
 .table-of-contents__link--active {
   @apply font-bold text-[color:var(--ifm-color-primary)];
 }
@@ -173,7 +178,8 @@ div[class^="sidebar_"] .button svg {
 }
 
 .center {
-  text-align: center; /* needed so that blog post heading is centered in the single blog post view */
+  text-align: center;
+  /* needed so that blog post heading is centered in the single blog post view */
 }
 
 /*
@@ -214,11 +220,13 @@ div[class^="sidebar_"] .button svg {
 .pagination-nav {
   @apply mt-12 flex flex-col items-start justify-center space-x-0 space-y-5 md:flex-row md:space-x-10 md:space-y-0;
 }
+
 .pagination-nav__item {
   @apply w-full max-w-md;
 }
+
 .pagination-nav__link {
-  @apply flex-grow transform rounded-lg border-0 bg-[color:var(--ifm-card-background-color)] p-5  text-lg shadow-lg transition-transform hover:scale-105;
+  @apply flex-grow transform rounded-lg border-0 bg-[color:var(--ifm-card-background-color)] p-5 text-lg shadow-lg transition-transform hover:scale-105;
 }
 
 /* Navbar */
@@ -475,6 +483,7 @@ td img {
 .prose .tabs-container > .tabs > .tabs__item::before {
   content: none;
 }
+
 .prose .tabs-container > .tabs > .tabs__item {
   padding-left: 1em;
   padding-top: 0.5em;
@@ -482,6 +491,7 @@ td img {
   margin-bottom: 0em;
   opacity: 0.5;
 }
+
 .prose .tabs-container > .tabs > .tabs__item.tabs__item--active {
   opacity: 1;
 }
@@ -489,26 +499,33 @@ td img {
 .prose .tabs {
   padding: 0 !important;
 }
+
 .prose .tabs-container ul {
   margin: 0;
   margin-bottom: -1.25rem;
 }
+
 .prose .tabs-container > .margin-vert--md pre {
   margin: 0;
 }
+
 /* otherwise tailwind typography gives very ugly margins on inline images */
 .prose li img {
   margin: 0;
 }
+
 /* otherwise tailwind typography gives very ugly margins on li children */
 .prose > ol > li > :first-child,
 .prose > ul > li > :first-child,
 .prose > ol > li > :last-child,
 .prose > ul > li > :last-child {
-  margin: 0 !important; /* sorry cant figure out how else to do this, prose @media overriding - swyx */
+  margin: 0 !important;
+  /* sorry cant figure out how else to do this, prose @media overriding - swyx */
 }
+
 .prose li > ul {
-  margin-top: 1rem !important; /* sorry cant figure out how else to do this, prose @media overriding - swyx */
+  margin-top: 1rem !important;
+  /* sorry cant figure out how else to do this, prose @media overriding - swyx */
 }
 
 .prose :where(a code) {
@@ -525,9 +542,11 @@ td img {
   padding: 0;
   font-size: 0.95em;
 }
+
 [data-theme="light"] .prose :where(pre code):not(.not-prose) {
   background-color: #ffffff;
 }
+
 [data-theme="light"]
   .prose
   :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
@@ -742,6 +761,11 @@ a {
 
 textarea {
   resize: vertical;
+}
+
+/* TODO: Define --ifm-color-accent in your theme CSS if not already present */
+:root {
+  --ifm-color-accent: #f1ccb1;
 }
 
 .theme-back-to-top-button {

--- a/src/pages/concepts/reference/glossary.js
+++ b/src/pages/concepts/reference/glossary.js
@@ -155,7 +155,7 @@ function Glossary() {
           <svg width="32" height="32" viewBox="0 0 24 24">
             <path
               d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-              fill="#f1ccb1"
+              fill="var(--ifm-color-accent)"
             />
           </svg>
         </button>

--- a/src/pages/concepts/reference/glossary.js
+++ b/src/pages/concepts/reference/glossary.js
@@ -1,4 +1,4 @@
-import React, {useState, useMemo} from "react";
+import React, {useState, useMemo, useEffect} from "react";
 import Layout from "@theme/Layout";
 
 import {glossaryEntries} from "../../../../static/data/glossaryEntries";
@@ -6,6 +6,7 @@ import GlossaryCard from "../../../components/GlossaryCard";
 
 function Glossary() {
   const [selectedletter, setselectedletter] = useState([]);
+  const [showBackToTop, setShowBackToTop] = useState(false);
 
   const allLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
   const availableLetters = Object.keys(glossaryEntries);
@@ -21,6 +22,23 @@ function Glossary() {
   // Reset filter
   const handleResetFilter = () => {
     setselectedletter([]);
+  };
+
+  // Back to top functionality
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowBackToTop(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
   };
 
   // Memoize the filtered entries to avoid re calculating on every render
@@ -128,6 +146,20 @@ function Glossary() {
           )}
         </div>
       </main>
+      {showBackToTop && (
+        <button
+          onClick={scrollToTop}
+          className="theme-back-to-top-button fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full shadow-lg"
+          aria-label="Back to top"
+        >
+          <svg width="32" height="32" viewBox="0 0 24 24">
+            <path
+              d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+              fill="#f1ccb1"
+            />
+          </svg>
+        </button>
+      )}
     </Layout>
   );
 }


### PR DESCRIPTION
# Add back-to-top button to glossary page

- Add scroll-triggered back-to-top functionality
- Implement smooth scrolling behavior
- Style with Keploy orange theme colors
- Position as fixed button in bottom-right corner
- Show button after scrolling 300px from top
- Add proper accessibility with aria-label

Fixes #3086

## What has changed?

This PR adds a back-to-top button to the glossary page (`/concepts/reference/glossary`) to improve user experience when navigating through the extensive glossary content. The button appears after scrolling 300px down the page and provides smooth scrolling back to the top.

**Key Changes:**
- **Added back-to-top functionality** in `src/pages/concepts/reference/glossary.js` with React hooks (`useState`, `useEffect`)
- **Implemented scroll detection** that shows/hides the button based on scroll position
- **Added smooth scrolling behavior** using `window.scrollTo({ behavior: "smooth" })`
- **Styled with Keploy brand colors** in `src/css/custom.css` using the orange theme (#ff914d)
- **Positioned as fixed button** in bottom-right corner with proper z-index
- **Added accessibility support** with `aria-label="Back to top"`
- **Included SVG arrow icon** pointing upward to indicate the button's function

This PR Resolves #3086

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update (if none of the other choices apply).

Demo: 
<img width="1903" height="908" alt="Screenshot 2025-10-05 221953" src="https://github.com/user-attachments/assets/88837fcb-5bd8-4e11-a318-114f2da465bd" />

## How Has This Been Tested?

The implementation has been tested locally using:

```bash
npm run build
npm run serve