### PR TITLE
fix: update announcement banner to use theme colors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -689,20 +689,34 @@ td img {
 }
 
 div[class^="announcementBar_"] {
-  --site-announcement-bar-stripe-color1: hsl(
-    var(--site-primary-hue-saturation) 88%
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-primary) 0%,
+    var(--ifm-color-primary-light) 100%
   );
-  --site-announcement-bar-stripe-color2: hsl(
-    var(--site-primary-hue-saturation) 95%
-  );
-  background: repeating-linear-gradient(
-    35deg,
-    var(--site-announcement-bar-stripe-color1),
-    var(--site-announcement-bar-stripe-color1) 20px,
-    var(--site-announcement-bar-stripe-color2) 10px,
-    var(--site-announcement-bar-stripe-color2) 40px
-  );
+  color: #ffffff;
   font-weight: bold;
+  border-bottom: 2px solid var(--ifm-color-primary-dark);
+}
+
+div[class^="announcementBar_"] a {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+div[class^="announcementBar_"] a:hover {
+  color: var(--ifm-color-primary-lightest);
+  text-decoration: underline;
+}
+
+html[data-theme="dark"] div[class^="announcementBar_"] {
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-primary) 0%,
+    var(--ifm-color-primary-dark) 100%
+  );
+  color: #ffffff;
+  border-bottom: 2px solid var(--ifm-color-primary-darker);
 }
 
 .list-disc > a {


### PR DESCRIPTION
- Replace plain white background with theme-based gradient
- Use primary color (#ff914d) and primary-light for attractive gradient
- Add proper text color (white) for better contrast and visibility
- Add border-bottom using primary-dark for visual separation
- Support both light and dark themes
- Style links within banner for consistency
- Make banner more noticeable and consistent with site design

## What has changed?

Please include a summary of the change.

This PR Resolves #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.


## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->