### PR TITLE
Add quickstarts for slim php framework with mongodb, mysql and postgresql

### DIFF
--- a/src/components/QuickStartFilter.js
+++ b/src/components/QuickStartFilter.js
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 import quickstarts from "./QuickStartList";
 import Link from "@docusaurus/Link";
-import {FaGolang} from "react-icons/fa6";
+import {FaGolang, FaPhp} from "react-icons/fa6";
 import {FaJava, FaLaptopCode, FaDocker, FaPython, FaCheck, FaArrowRight, FaArrowLeft} from "react-icons/fa";
 import {TbBrandCSharp} from "react-icons/tb";
 import {IoLogoJavascript} from "react-icons/io5";
@@ -28,6 +28,7 @@ export default function QuickstartFilter({defaultLanguage = null}) {
     {name: "Java", icon: <FaJava size={24} />, color: "#007396"},
     {name: "JS/TS", icon: <IoLogoJavascript size={24} />, color: "#F7DF1E"},
     {name: "C#", icon: <TbBrandCSharp size={24} />, color: "#512BD4"},
+    {name: "PHP", icon: <FaPhp size={24} />, color: "#777BB4"},
   ];
 
   const servers = [

--- a/src/components/QuickStartList.js
+++ b/src/components/QuickStartList.js
@@ -219,6 +219,38 @@ const quickstarts = [
       "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and MySQL.",
     link: "/docs/quickstart/samples-php/#running-app-locally-on-linuxwsl-",
   },
+  {
+    title: "Slim + PostgreSQL",
+    language: "PHP",
+    server: "Docker",
+    description:
+      "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and PostgreSQL.",
+    link: "/docs/quickstart/samples-php-postgres/#using-docker-compose-",
+  },
+  {
+    title: "Slim + PostgreSQL",
+    language: "PHP",
+    server: "Local",
+    description:
+      "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and PostgreSQL.",
+    link: "/docs/quickstart/samples-php-postgres/#running-app-locally-on-linuxwsl-",
+  },
+  {
+    title: "Slim + MongoDB",
+    language: "PHP",
+    server: "Docker",
+    description:
+      "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and MongoDB.",
+    link: "/docs/quickstart/samples-php-mongodb/#using-docker-compose-",
+  },
+  {
+    title: "Slim + MongoDB",
+    language: "PHP",
+    server: "Local",
+    description:
+      "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and MongoDB.",
+    link: "/docs/quickstart/samples-php-mongodb/#running-app-locally-on-linuxwsl-",
+  },
 
   // python list
 

--- a/src/components/QuickStartList.js
+++ b/src/components/QuickStartList.js
@@ -201,6 +201,25 @@ const quickstarts = [
     link: "/docs/quickstart/samples-csharp/",
   },
 
+  // php list
+
+  {
+    title: "Slim + MySQL",
+    language: "PHP",
+    server: "Docker",
+    description:
+      "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and MySQL.",
+    link: "/docs/quickstart/samples-php/#using-docker-compose-",
+  },
+  {
+    title: "Slim + MySQL",
+    language: "PHP",
+    server: "Local",
+    description:
+      "A sample Books CRUD API to demonstrate how seamlessly Keploy integrates with PHP Slim and MySQL.",
+    link: "/docs/quickstart/samples-php/#running-app-locally-on-linuxwsl-",
+  },
+
   // python list
 
   {

--- a/versioned_docs/version-4.0.0/quickstart/php-slim-mongodb.md
+++ b/versioned_docs/version-4.0.0/quickstart/php-slim-mongodb.md
@@ -49,7 +49,7 @@ First, let's set up the environment and start recording. Keep an eye on the key 
 docker network create keploy-network
 
 # Start MongoDB database
-docker compose up mongodb -d
+docker compose up -d mongodb
 
 # Build the application
 docker compose build app
@@ -164,7 +164,7 @@ docker network create keploy-network
 Now, let's breathe life into your MongoDB container. A simple spell should do the trick:
 
 ```bash
-docker compose up mongodb -d
+docker compose up -d mongodb
 ```
 
 #### Configure Environment

--- a/versioned_docs/version-4.0.0/quickstart/php-slim-mongodb.md
+++ b/versioned_docs/version-4.0.0/quickstart/php-slim-mongodb.md
@@ -1,0 +1,239 @@
+---
+id: samples-php-mongodb
+title: PHP Sample Application (MongoDB)
+sidebar_label: PHP - Slim + MongoDB
+description: The following sample app showcases how to use PHP Slim framework with MongoDB and the Keploy Platform.
+tags:
+  - php
+  - quickstart
+  - samples
+  - examples
+  - tutorial
+keyword:
+  - PHP Framework
+  - MongoDB
+  - Slim
+  - API Test generator
+  - Auto Testcase generation
+---
+
+import InstallReminder from '@site/src/components/InstallReminder';
+
+import SectionDivider from '@site/src/components/SectionDivider';
+
+## Using Docker Compose 🐳
+
+A simple sample CRUD Books API application and see how seamlessly Keploy integrates with PHP Slim and MongoDB. Buckle up, it's gonna be a fun ride! 🎢
+
+<InstallReminder />
+
+### Get Started! 🎬
+
+Clone the repository and move to slim-mongodb folder
+
+```bash
+git clone https://github.com/swastikiscoding/samples-php.git && cd samples-php/slim-mongodb
+```
+
+We will be using Docker compose to run the application as well as MongoDB on Docker container.
+
+### Lights, Camera, Record! 🎥
+
+First, let's set up the environment and start recording. Keep an eye on the key flags:
+`-c`: Command to run the app (e.g., `docker compose up`).
+
+`--container-name`: The container name in the `docker-compose.yml` for traffic interception.
+
+```bash
+# Create network
+docker network create keploy-network
+
+# Start MongoDB database
+docker compose up mongodb -d
+
+# Build the application
+docker compose build app
+
+# Start recording with Keploy
+keploy record -c "docker compose up app" --container-name "slim-mongodb-app-1" -n keploy-network
+```
+
+🔥 Challenge time! Generate some test cases. How? Just **make some API calls**. Postman, Hoppscotch or even curl - take your pick!
+
+#### Let's generate the testcases.
+
+Make API Calls using Postman or cURL command. Keploy will capture those calls to generate the test-suites containing testcases and data mocks.
+
+```bash
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan", "price": 44.99}'
+```
+
+Here's a peek of what you get:
+
+```json
+{"title":"The Go Programming Language","author":"Alan Donovan","price":44.99,"id":"507f1f77bcf86cd799439011"}
+```
+
+> **Note**: MongoDB uses ObjectId format for IDs (e.g., `507f1f77bcf86cd799439011`). Copy the `id` from the POST response to use in subsequent requests.
+
+🎉 Woohoo! With a simple API call, you've crafted a test case with a mock! Dive into the Keploy directory and feast your eyes on the newly minted `test-1.yml` and `mocks.yml`
+
+_Time to perform more API magic!_
+Follow the breadcrumbs... or Make more API Calls
+
+```bash
+# Create more books
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Clean Code", "author": "Robert C. Martin", "price": 39.99}'
+
+# Get all books
+curl http://localhost:8080/api/books
+
+# Get a specific book (replace <BOOK_ID> with actual ID from previous response)
+curl http://localhost:8080/api/books/<BOOK_ID>
+
+# Update a book (replace <BOOK_ID> with actual ID)
+curl -X PUT http://localhost:8080/api/books/<BOOK_ID> \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan & Brian Kernighan", "price": 49.99}'
+
+# Delete a book (replace <BOOK_ID> with actual ID)
+curl -X DELETE http://localhost:8080/api/books/<BOOK_ID>
+```
+
+Did you spot the new test and mock scrolls in your project library? Awesome! 👏
+
+### Run Tests
+
+Time to put things to the test 🧪
+
+```bash
+# Stop any running containers
+docker compose down
+
+# Run Keploy tests
+keploy test -c "docker compose up app" --container-name "slim-mongodb-app-1" -n keploy-network --delay 10
+```
+
+> The `--delay` flag? Oh, that's just giving your app a little breather (in seconds) before the test cases come knocking.
+
+### Wrapping it up 🎉
+
+Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
+
+Happy coding! ✨👩‍💻👨‍💻✨
+
+<SectionDivider />
+
+## Running App Locally on Linux/WSL 🐧
+
+A simple sample CRUD Books API application and see how seamlessly Keploy integrates with PHP Slim and MongoDB. Buckle up, it's gonna be a fun ride! 🎢
+
+<InstallReminder />
+
+### Get Started! 🎬
+
+Clone the repository and move to slim-mongodb folder
+
+```bash
+git clone https://github.com/swastikiscoding/samples-php.git && cd samples-php/slim-mongodb
+
+# Install the dependencies
+composer install
+```
+
+We'll be running our sample application right on Linux, but just to make things a tad more thrilling, we'll have the database (MongoDB) chill on Docker. Ready? Let's get the party started!🎉
+
+If you are using WSL on windows then use below to start wsl in the user's home directory:
+
+```bash
+wsl ~
+```
+
+#### 🍃 Kickstart MongoDB
+
+We are going to run a MongoDB docker container which requires an existing docker network. We need to run the following command to create the required docker network:
+
+```bash
+docker network create keploy-network
+```
+
+Now, let's breathe life into your MongoDB container. A simple spell should do the trick:
+
+```bash
+docker compose up mongodb -d
+```
+
+#### Configure Environment
+
+Set up the database connection environment variables:
+
+```bash
+export MONGO_URI=mongodb://localhost:27017
+export DB_NAME=booksdb
+```
+
+### 📼 Roll the Tape - Recording Time!
+
+Ready, set, record! Here's how:
+
+```bash
+sudo -E env PATH=$PATH keploy record -c 'php -S localhost:8080 -t public'
+```
+
+Keep an eye out for the `-c` flag! It's the command charm to run the app.
+
+Alright, magician! With the app alive and kicking, let's weave some test cases. The spell? Making some API calls! Postman, Hoppscotch, or the classic curl - pick your wand.
+
+#### Let's generate the testcases.
+
+Make API Calls using Postman or cURL command. Keploy will capture those calls to generate the test-suites containing testcases and data mocks.
+
+```bash
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan", "price": 44.99}'
+```
+
+Here's a peek of what you get:
+
+```json
+{"title":"The Go Programming Language","author":"Alan Donovan","price":44.99,"id":"507f1f77bcf86cd799439011"}
+```
+
+🎉 Woohoo! Give yourself a pat on the back! With that simple spell, you've conjured up a test case with a mock! Explore the **Keploy directory** and you'll discover your handiwork in `test-1.yml` and `mocks.yml`.
+
+Now, the real fun begins. Let's weave more spells!
+
+🚀 Follow the URL road...!
+
+```bash
+# Get all books
+curl http://localhost:8080/api/books
+
+# Create another book
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Clean Code", "author": "Robert C. Martin", "price": 39.99}'
+```
+
+Or simply wander over to your browser and visit `http://localhost:8080/api/books`.
+
+Did you spot the new test and mock scrolls in your project library? Awesome! 👏
+
+### Run Tests 🏁
+
+Ready to put your spells to the test?
+
+```bash
+sudo -E env PATH=$PATH keploy test -c "php -S localhost:8080 -t public" --delay 10
+```
+
+### Wrapping it up 🎉
+
+Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
+
+Happy coding! ✨👩‍💻👨‍💻✨

--- a/versioned_docs/version-4.0.0/quickstart/php-slim-mysql.md
+++ b/versioned_docs/version-4.0.0/quickstart/php-slim-mysql.md
@@ -1,8 +1,8 @@
 ---
 id: samples-php
-title: PHP Sample Application
+title: PHP Slim + MySQL Sample Application
 sidebar_label: PHP - Slim + MySQL
-description: The following sample app showcases how to use PHP Slim framework and the Keploy Platform.
+description: The following sample app showcases how to use the PHP Slim framework with MySQL and the Keploy Platform.
 tags:
   - php
   - quickstart
@@ -49,7 +49,7 @@ First, let's set up the environment and start recording. Keep an eye on the key 
 docker network create keploy-network
 
 # Start MySQL database
-docker compose up mysql -d
+docker compose up -d mysql
 
 # Build the application
 docker compose build app
@@ -162,7 +162,7 @@ docker network create keploy-network
 Now, let's breathe life into your MySQL container. A simple spell should do the trick:
 
 ```bash
-docker compose up mysql -d
+docker compose up -d mysql
 ```
 
 #### Configure Environment

--- a/versioned_docs/version-4.0.0/quickstart/php-slim-mysql.md
+++ b/versioned_docs/version-4.0.0/quickstart/php-slim-mysql.md
@@ -1,0 +1,240 @@
+---
+id: samples-php
+title: PHP Sample Application
+sidebar_label: PHP - Slim + MySQL
+description: The following sample app showcases how to use PHP Slim framework and the Keploy Platform.
+tags:
+  - php
+  - quickstart
+  - samples
+  - examples
+  - tutorial
+keyword:
+  - PHP Framework
+  - MySQL
+  - Slim
+  - API Test generator
+  - Auto Testcase generation
+---
+
+import InstallReminder from '@site/src/components/InstallReminder';
+
+import SectionDivider from '@site/src/components/SectionDivider';
+
+## Using Docker Compose 🐳
+
+A simple sample CRUD Books API application and see how seamlessly Keploy integrates with PHP Slim and MySQL. Buckle up, it's gonna be a fun ride! 🎢
+
+<InstallReminder />
+
+### Get Started! 🎬
+
+Clone the repository and move to slim-mysql folder
+
+```bash
+git clone https://github.com/swastikiscoding/samples-php.git && cd samples-php/slim-mysql
+```
+
+We will be using Docker compose to run the application as well as MySQL on Docker container.
+
+### Lights, Camera, Record! 🎥
+
+First, let's set up the environment and start recording. Keep an eye on the key flags:
+`-c`: Command to run the app (e.g., `docker compose up`).
+
+`--container-name`: The container name in the `docker-compose.yml` for traffic interception.
+
+```bash
+# Create network
+docker network create keploy-network
+
+# Start MySQL database
+docker compose up mysql -d
+
+# Build the application
+docker compose build app
+
+# Start recording with Keploy
+keploy record -c "docker compose up app" --container-name "slim-mysql-app-1" -n keploy-network
+```
+
+🔥 Challenge time! Generate some test cases. How? Just **make some API calls**. Postman, Hoppscotch or even curl - take your pick!
+
+#### Let's generate the testcases.
+
+Make API Calls using Postman or cURL command. Keploy will capture those calls to generate the test-suites containing testcases and data mocks.
+
+```bash
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan", "price": 44.99}'
+```
+
+Here's a peek of what you get:
+
+```json
+{"id":1,"title":"The Go Programming Language","author":"Alan Donovan","price":"44.99"}
+```
+
+🎉 Woohoo! With a simple API call, you've crafted a test case with a mock! Dive into the Keploy directory and feast your eyes on the newly minted `test-1.yml` and `mocks.yml`
+
+_Time to perform more API magic!_
+Follow the breadcrumbs... or Make more API Calls
+
+```bash
+# Create more books
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Clean Code", "author": "Robert C. Martin", "price": 39.99}'
+
+# Get all books
+curl http://localhost:8080/api/books
+
+# Get a specific book
+curl http://localhost:8080/api/books/1
+
+# Update a book
+curl -X PUT http://localhost:8080/api/books/1 \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan & Brian Kernighan", "price": 49.99}'
+
+# Delete a book
+curl -X DELETE http://localhost:8080/api/books/2
+```
+
+Did you spot the new test and mock scrolls in your project library? Awesome! 👏
+
+### Run Tests
+
+Time to put things to the test 🧪
+
+```bash
+# Stop any running containers
+docker compose down
+
+# Run Keploy tests
+keploy test -c "docker compose up app" --container-name "slim-mysql-app-1" -n keploy-network --delay 10
+```
+
+> The `--delay` flag? Oh, that's just giving your app a little breather (in seconds) before the test cases come knocking.
+
+### Wrapping it up 🎉
+
+Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
+
+Happy coding! ✨👩‍💻👨‍💻✨
+
+<SectionDivider />
+
+## Running App Locally on Linux/WSL 🐧
+
+A simple sample CRUD Books API application and see how seamlessly Keploy integrates with PHP Slim and MySQL. Buckle up, it's gonna be a fun ride! 🎢
+
+<InstallReminder />
+
+### Get Started! 🎬
+
+Clone the repository and move to slim-mysql folder
+
+```bash
+git clone https://github.com/swastikiscoding/samples-php.git && cd samples-php/slim-mysql
+
+# Install the dependencies
+composer install
+```
+
+We'll be running our sample application right on Linux, but just to make things a tad more thrilling, we'll have the database (MySQL) chill on Docker. Ready? Let's get the party started!🎉
+
+If you are using WSL on windows then use below to start wsl in the user's home directory:
+
+```bash
+wsl ~
+```
+
+#### 🍃 Kickstart MySQL
+
+We are going to run a MySQL docker container which requires an existing docker network. We need to run the following command to create the required docker network:
+
+```bash
+docker network create keploy-network
+```
+
+Now, let's breathe life into your MySQL container. A simple spell should do the trick:
+
+```bash
+docker compose up mysql -d
+```
+
+#### Configure Environment
+
+Set up the database connection environment variables:
+
+```bash
+export DB_HOST=localhost
+export DB_PORT=3306
+export DB_NAME=booksdb
+export DB_USER=bookuser
+export DB_PASS=bookpass
+```
+
+### 📼 Roll the Tape - Recording Time!
+
+Ready, set, record! Here's how:
+
+```bash
+sudo -E env PATH=$PATH keploy record -c 'php -S localhost:8080 -t public'
+```
+
+Keep an eye out for the `-c` flag! It's the command charm to run the app.
+
+Alright, magician! With the app alive and kicking, let's weave some test cases. The spell? Making some API calls! Postman, Hoppscotch, or the classic curl - pick your wand.
+
+#### Let's generate the testcases.
+
+Make API Calls using Postman or cURL command. Keploy will capture those calls to generate the test-suites containing testcases and data mocks.
+
+```bash
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan", "price": 44.99}'
+```
+
+Here's a peek of what you get:
+
+```json
+{"id":1,"title":"The Go Programming Language","author":"Alan Donovan","price":"44.99"}
+```
+
+🎉 Woohoo! Give yourself a pat on the back! With that simple spell, you've conjured up a test case with a mock! Explore the **Keploy directory** and you'll discover your handiwork in `test-1.yml` and `mocks.yml`.
+
+Now, the real fun begins. Let's weave more spells!
+
+🚀 Follow the URL road...!
+
+```bash
+# Get all books
+curl http://localhost:8080/api/books
+
+# Create another book
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Clean Code", "author": "Robert C. Martin", "price": 39.99}'
+```
+
+Or simply wander over to your browser and visit `http://localhost:8080/api/books`.
+
+Did you spot the new test and mock scrolls in your project library? Awesome! 👏
+
+### Run Tests 🏁
+
+Ready to put your spells to the test?
+
+```bash
+sudo -E env PATH=$PATH keploy test -c "php -S localhost:8080 -t public" --delay 10
+```
+
+### Wrapping it up 🎉
+
+Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
+
+Happy coding! ✨👩‍💻👨‍💻✨

--- a/versioned_docs/version-4.0.0/quickstart/php-slim-postgres.md
+++ b/versioned_docs/version-4.0.0/quickstart/php-slim-postgres.md
@@ -49,7 +49,7 @@ First, let's set up the environment and start recording. Keep an eye on the key 
 docker network create keploy-network
 
 # Start PostgreSQL database
-docker compose up postgres -d
+docker compose up -d postgres
 
 # Build the application
 docker compose build app
@@ -162,7 +162,7 @@ docker network create keploy-network
 Now, let's breathe life into your PostgreSQL container. A simple spell should do the trick:
 
 ```bash
-docker compose up postgres -d
+docker compose up -d postgres
 ```
 
 #### Configure Environment

--- a/versioned_docs/version-4.0.0/quickstart/php-slim-postgres.md
+++ b/versioned_docs/version-4.0.0/quickstart/php-slim-postgres.md
@@ -1,0 +1,240 @@
+---
+id: samples-php-postgres
+title: PHP Sample Application (PostgreSQL)
+sidebar_label: PHP - Slim + PostgreSQL
+description: The following sample app showcases how to use PHP Slim framework with PostgreSQL and the Keploy Platform.
+tags:
+  - php
+  - quickstart
+  - samples
+  - examples
+  - tutorial
+keyword:
+  - PHP Framework
+  - PostgreSQL
+  - Slim
+  - API Test generator
+  - Auto Testcase generation
+---
+
+import InstallReminder from '@site/src/components/InstallReminder';
+
+import SectionDivider from '@site/src/components/SectionDivider';
+
+## Using Docker Compose 🐳
+
+A simple sample CRUD Books API application and see how seamlessly Keploy integrates with PHP Slim and PostgreSQL. Buckle up, it's gonna be a fun ride! 🎢
+
+<InstallReminder />
+
+### Get Started! 🎬
+
+Clone the repository and move to slim-postgres folder
+
+```bash
+git clone https://github.com/swastikiscoding/samples-php.git && cd samples-php/slim-postgres
+```
+
+We will be using Docker compose to run the application as well as PostgreSQL on Docker container.
+
+### Lights, Camera, Record! 🎥
+
+First, let's set up the environment and start recording. Keep an eye on the key flags:
+`-c`: Command to run the app (e.g., `docker compose up`).
+
+`--container-name`: The container name in the `docker-compose.yml` for traffic interception.
+
+```bash
+# Create network
+docker network create keploy-network
+
+# Start PostgreSQL database
+docker compose up postgres -d
+
+# Build the application
+docker compose build app
+
+# Start recording with Keploy
+keploy record -c "docker compose up app" --container-name "slim-postgres-app-1" -n keploy-network
+```
+
+🔥 Challenge time! Generate some test cases. How? Just **make some API calls**. Postman, Hoppscotch or even curl - take your pick!
+
+#### Let's generate the testcases.
+
+Make API Calls using Postman or cURL command. Keploy will capture those calls to generate the test-suites containing testcases and data mocks.
+
+```bash
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan", "price": 44.99}'
+```
+
+Here's a peek of what you get:
+
+```json
+{"id":1,"title":"The Go Programming Language","author":"Alan Donovan","price":"44.99"}
+```
+
+🎉 Woohoo! With a simple API call, you've crafted a test case with a mock! Dive into the Keploy directory and feast your eyes on the newly minted `test-1.yml` and `mocks.yml`
+
+_Time to perform more API magic!_
+Follow the breadcrumbs... or Make more API Calls
+
+```bash
+# Create more books
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Clean Code", "author": "Robert C. Martin", "price": 39.99}'
+
+# Get all books
+curl http://localhost:8080/api/books
+
+# Get a specific book
+curl http://localhost:8080/api/books/1
+
+# Update a book
+curl -X PUT http://localhost:8080/api/books/1 \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan & Brian Kernighan", "price": 49.99}'
+
+# Delete a book
+curl -X DELETE http://localhost:8080/api/books/2
+```
+
+Did you spot the new test and mock scrolls in your project library? Awesome! 👏
+
+### Run Tests
+
+Time to put things to the test 🧪
+
+```bash
+# Stop any running containers
+docker compose down
+
+# Run Keploy tests
+keploy test -c "docker compose up app" --container-name "slim-postgres-app-1" -n keploy-network --delay 10
+```
+
+> The `--delay` flag? Oh, that's just giving your app a little breather (in seconds) before the test cases come knocking.
+
+### Wrapping it up 🎉
+
+Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
+
+Happy coding! ✨👩‍💻👨‍💻✨
+
+<SectionDivider />
+
+## Running App Locally on Linux/WSL 🐧
+
+A simple sample CRUD Books API application and see how seamlessly Keploy integrates with PHP Slim and PostgreSQL. Buckle up, it's gonna be a fun ride! 🎢
+
+<InstallReminder />
+
+### Get Started! 🎬
+
+Clone the repository and move to slim-postgres folder
+
+```bash
+git clone https://github.com/swastikiscoding/samples-php.git && cd samples-php/slim-postgres
+
+# Install the dependencies
+composer install
+```
+
+We'll be running our sample application right on Linux, but just to make things a tad more thrilling, we'll have the database (PostgreSQL) chill on Docker. Ready? Let's get the party started!🎉
+
+If you are using WSL on windows then use below to start wsl in the user's home directory:
+
+```bash
+wsl ~
+```
+
+#### 🍃 Kickstart PostgreSQL
+
+We are going to run a PostgreSQL docker container which requires an existing docker network. We need to run the following command to create the required docker network:
+
+```bash
+docker network create keploy-network
+```
+
+Now, let's breathe life into your PostgreSQL container. A simple spell should do the trick:
+
+```bash
+docker compose up postgres -d
+```
+
+#### Configure Environment
+
+Set up the database connection environment variables:
+
+```bash
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_NAME=booksdb
+export DB_USER=bookuser
+export DB_PASS=bookpass
+```
+
+### 📼 Roll the Tape - Recording Time!
+
+Ready, set, record! Here's how:
+
+```bash
+sudo -E env PATH=$PATH keploy record -c 'php -S localhost:8080 -t public'
+```
+
+Keep an eye out for the `-c` flag! It's the command charm to run the app.
+
+Alright, magician! With the app alive and kicking, let's weave some test cases. The spell? Making some API calls! Postman, Hoppscotch, or the classic curl - pick your wand.
+
+#### Let's generate the testcases.
+
+Make API Calls using Postman or cURL command. Keploy will capture those calls to generate the test-suites containing testcases and data mocks.
+
+```bash
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "The Go Programming Language", "author": "Alan Donovan", "price": 44.99}'
+```
+
+Here's a peek of what you get:
+
+```json
+{"id":1,"title":"The Go Programming Language","author":"Alan Donovan","price":"44.99"}
+```
+
+🎉 Woohoo! Give yourself a pat on the back! With that simple spell, you've conjured up a test case with a mock! Explore the **Keploy directory** and you'll discover your handiwork in `test-1.yml` and `mocks.yml`.
+
+Now, the real fun begins. Let's weave more spells!
+
+🚀 Follow the URL road...!
+
+```bash
+# Get all books
+curl http://localhost:8080/api/books
+
+# Create another book
+curl -X POST http://localhost:8080/api/books \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Clean Code", "author": "Robert C. Martin", "price": 39.99}'
+```
+
+Or simply wander over to your browser and visit `http://localhost:8080/api/books`.
+
+Did you spot the new test and mock scrolls in your project library? Awesome! 👏
+
+### Run Tests 🏁
+
+Ready to put your spells to the test?
+
+```bash
+sudo -E env PATH=$PATH keploy test -c "php -S localhost:8080 -t public" --delay 10
+```
+
+### Wrapping it up 🎉
+
+Congrats on the journey so far! You've seen Keploy's power, flexed your coding muscles, and had a bit of fun too! Now, go out there and keep exploring, innovating, and creating! Remember, with the right tools and a sprinkle of fun, anything's possible.😊🚀
+
+Happy coding! ✨👩‍💻👨‍💻✨

--- a/versioned_sidebars/version-4.0.0-sidebars.json
+++ b/versioned_sidebars/version-4.0.0-sidebars.json
@@ -125,7 +125,9 @@
               "collapsible": true,
               "collapsed": true,
               "items": [
-                "quickstart/samples-php"
+                "quickstart/samples-php",
+                "quickstart/samples-php-postgres",
+                "quickstart/samples-php-mongodb"
               ]
             }
           ]

--- a/versioned_sidebars/version-4.0.0-sidebars.json
+++ b/versioned_sidebars/version-4.0.0-sidebars.json
@@ -118,6 +118,15 @@
               "items": [
                 "quickstart/samples-csharp"
               ]
+            },
+            {
+              "type": "category",
+              "label": "PHP",
+              "collapsible": true,
+              "collapsed": true,
+              "items": [
+                "quickstart/samples-php"
+              ]
             }
           ]
         },


### PR DESCRIPTION
## What has changed?

This PR adds new quickstart guides for slim php framework with mongodb, mysql and postgresql databses.
It has both local and docker setups enabling developers to easily integrate keploy for API testing.
This PR Resolves https://github.com/keploy/keploy/issues/3521

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?
<img width="789" height="637" alt="image" src="https://github.com/user-attachments/assets/c4eae8e8-0ef8-4a71-b929-75f3f844d8b2" />

https://github.com/user-attachments/assets/a4e3f0b8-9555-447f-8f62-7120b94697ef



## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->