### PR TITLE
chatbot - chatwoot 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -375,6 +375,11 @@ module.exports = {
       async: true,
       defer: true,
     },
+    {
+      src: "/docs/scripts/chatwoot.js",
+      async: true,
+      defer: true,
+    },
     /*{
       src: "/docs/scripts/chat.js",
       async: true,

--- a/static/scripts/chatwoot.js
+++ b/static/scripts/chatwoot.js
@@ -1,0 +1,13 @@
+(function(d,t) {
+  var BASE_URL="https://chatwoot.keploy.io";
+  var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+  g.src=BASE_URL+"/packs/js/sdk.js";
+  g.async = true;
+  s.parentNode.insertBefore(g,s);
+  g.onload=function(){
+    window.chatwootSDK.run({
+      websiteToken: 'DNsHCafpdxqz3dDU1SPggAon',
+      baseUrl: BASE_URL
+    })
+  }
+})(document,"script");


### PR DESCRIPTION
This pull request adds support for integrating Chatwoot live chat to the documentation site. The main changes include loading the Chatwoot script and initializing it with the appropriate configuration.

**Chatwoot integration:**

* Added a new script entry for `/docs/scripts/chatwoot.js` in the `docusaurus.config.js` file to ensure the Chatwoot widget is loaded on documentation pages.
* Created the `static/scripts/chatwoot.js` script, which loads the Chatwoot SDK and initializes it with the correct website token and base URL.