### PR TITLE
fix: DocSearch input styling

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -426,6 +426,53 @@ html[data-theme="dark"] .navbar {
   color: #ffffff;
 }
 
+/* 1. Create gap between Magnifying Glass and the orange input box */
+.DocSearch-MagnifierLabel {
+  margin-left: 0.2px !important; /* Adjust this value for a larger/smaller gap */
+  margin-right: 8px !important;  /* Space between icon and the text you type */
+  color: var(--ifm-color-primary) !important; /* Optional: makes icon match Keploy blue */
+}
+
+/* Make form stretch fully */
+.DocSearch-Form {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 2px solid orange !important;
+  border-radius: 6px;
+  padding: 0;
+}
+
+/* Let wrapper take full width */
+.DocSearch-InputWrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  box-shadow: none !important;
+  border: none !important;
+  padding-left: 12px;
+}
+
+/* Clean input */
+.DocSearch-Input {
+  flex: 1;
+  border: none !important;
+  outline: none !important;
+  min-width: 0;
+  background: transparent;
+
+  /* 👇 prevents text from going under clear button */
+  padding-right: 110px; 
+}
+
+/* Keep clear text spacing */
+.DocSearch-Clear {
+  margin-left: 8px;
+  white-space: nowrap;
+}
+
+
+
 /* Footer */
 
 footer svg {


### PR DESCRIPTION
## What has changed?
The current search bar looks quite messy with the magnifying icon overlapping the orange border and the button "clear the query" coming half in the box and half out. 

<img width="1919" height="981" alt="Screenshot 2026-02-14 141511" src="https://github.com/user-attachments/assets/12f68a5e-6f95-425a-80e3-67a0f3043e33" />
<img width="397" height="862" alt="Screenshot 2026-02-14 143501" src="https://github.com/user-attachments/assets/954605da-32a9-443d-822d-71b72b147b8a" />

This PR tries to fix these issues but adjusting the orange border properly across full length and shifting the magnifying label to the left. Now, there is no overlapping of the icon and between the clear button and orange border.

<img width="1908" height="977" alt="image" src="https://github.com/user-attachments/assets/12d29192-d434-43ea-b7c6-a1d9ef376271" />
<img width="1054" height="944" alt="Screenshot 2026-02-14 143550" src="https://github.com/user-attachments/assets/3178624a-3c2c-4be6-95cd-8c031cefb247" />



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [-] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update (if none of the other choices apply).

## How Has This Been Tested?
Please test this using - npm run start


## Checklist:

- [-] My code follows the style guidelines of this project.
- [-] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->