### PR TITLE
docs: add JUnit XML Reports page

### DIFF
--- a/versioned_docs/version-4.0.0/keploy-cloud/junit-xml-reports.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/junit-xml-reports.md
@@ -1,0 +1,146 @@
+---
+id: junit-xml-reports
+title: JUnit XML Reports
+description: Export Keploy test results as JUnit XML for CI dashboards and trend tracking
+sidebar_label: JUnit XML Reports
+keywords:
+  - junit
+  - junit xml
+  - test reports
+  - ci testing
+  - ci/cd
+  - github actions
+  - jenkins
+  - gitlab
+  - test results
+tags:
+  - junit
+  - ci
+  - reports
+---
+
+import ProductTier from '@site/src/components/ProductTier';
+
+<ProductTier tiers="Open Source, Enterprise" offerings="Self-Hosted, Dedicated" />
+
+Keploy supports exporting test results as standard JUnit XML. Use `--format junit` flag on the `keploy report` command — CI systems parse the output natively, no plugins or custom parsers needed.
+Supported CI systems: GitHub Actions, GitLab CI, Jenkins, CircleCI, Azure DevOps.
+
+## Usage
+
+```bash
+keploy test -c "<CMD_TO_RUN_APP>" --delay 10
+keploy report --format junit > test-results.xml
+```
+
+To scope the report to specific test-sets:
+
+```bash
+keploy report --format junit --test-sets "test-set-1"
+```
+
+The default format remains `text` — existing workflows are unaffected.
+
+## Output Structure
+
+| Keploy Concept | JUnit XML Element |
+|---|---|
+| Test-set | `<testsuite>` |
+| Test case | `<testcase>` |
+| Failed test | `<failure>` with diff summary |
+| Obsolete test | `<skipped>` |
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="5" failures="1" time="2.300">
+  <testsuite name="test-set-1" tests="3" failures="1" skipped="0" time="1.500">
+    <testcase name="tc-1" classname="test-set-1" time="0.500"></testcase>
+    <testcase name="tc-2" classname="test-set-1" time="0.400"></testcase>
+    <testcase name="tc-3" classname="test-set-1" time="0.600">
+      <failure message="test assertion failed [HIGH-RISK]" type="AssertionError">status: expected 200, got 500
+body mismatch (JSON)</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="test-set-2" tests="2" failures="0" skipped="1" time="0.800">
+    <testcase name="tc-4" classname="test-set-2" time="0.300"></testcase>
+    <testcase name="tc-5" classname="test-set-2" time="0.500">
+      <skipped message="obsolete test case"></skipped>
+    </testcase>
+  </testsuite>
+</testsuites>
+```
+
+## CI Configuration
+
+### GitHub Actions
+
+```yaml
+- name: Run Keploy Tests
+  run: keploy test -c "<CMD_TO_RUN_APP>" --delay 10
+
+- name: Generate JUnit Report
+  run: keploy report --format junit > test-results.xml
+
+- name: Publish Test Results
+  uses: EnricoMi/publish-unit-test-result-action@v2
+  with:
+    files: test-results.xml
+```
+
+Results appear in the workflow summary under the **Tests** tab.
+
+---
+
+### GitLab CI
+
+```yaml
+keploy-test:
+  script:
+    - keploy test -c "<CMD_TO_RUN_APP>" --delay 10
+    - keploy report --format junit > test-results.xml
+  artifacts:
+    when: always
+    reports:
+      junit: test-results.xml
+```
+
+Results appear in the pipeline **Tests** tab.
+
+---
+
+### Jenkins
+
+```groovy
+stage('Keploy Test') {
+  steps {
+    sh 'keploy test -c "<CMD_TO_RUN_APP>" --delay 10'
+    sh 'keploy report --format junit > test-results.xml'
+  }
+  post {
+    always {
+      junit 'test-results.xml'
+    }
+  }
+}
+```
+
+Results appear under **Test Results** in the build view with trend tracking across builds.
+
+---
+
+### CircleCI
+
+```yaml
+- run:
+    name: Run Keploy Tests
+    command: keploy test -c "<CMD_TO_RUN_APP>" --delay 10
+
+- run:
+    name: Generate JUnit Report
+    command: keploy report --format junit > ~/test-results/keploy/results.xml
+
+- store_test_results:
+    path: ~/test-results
+```
+
+Results appear in the **Tests** tab of the pipeline run.

--- a/versioned_docs/version-4.0.0/keploy-cloud/junit-xml-reports.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/junit-xml-reports.md
@@ -23,8 +23,8 @@ import ProductTier from '@site/src/components/ProductTier';
 
 <ProductTier tiers="Open Source, Enterprise" offerings="Self-Hosted, Dedicated" />
 
-Keploy supports exporting test results as standard JUnit XML. Use `--format junit` flag on the `keploy report` command — CI systems parse the output natively, no plugins or custom parsers needed.
-Supported CI systems: GitHub Actions, GitLab CI, Jenkins, CircleCI, Azure DevOps.
+Keploy supports exporting test results as standard JUnit XML. Use `--format junit` flag on the `keploy report` command — it is a user-defined config and does not need any external plugin. 
+
 
 ## Usage
 
@@ -50,6 +50,9 @@ The default format remains `text` — existing workflows are unaffected.
 | Failed test | `<failure>` with diff summary |
 | Obsolete test | `<skipped>` |
 
+### Sample Output
+
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="5" failures="1" time="2.300">
@@ -72,75 +75,18 @@ body mismatch (JSON)</failure>
 
 ## CI Configuration
 
-### GitHub Actions
+### Config Example using GitHub Actions
 
 ```yaml
 - name: Run Keploy Tests
+  id: keploy-test
   run: keploy test -c "<CMD_TO_RUN_APP>" --delay 10
+  continue-on-error: true
 
 - name: Generate JUnit Report
+  if: always()
   run: keploy report --format junit > test-results.xml
-
-- name: Publish Test Results
-  uses: EnricoMi/publish-unit-test-result-action@v2
-  with:
-    files: test-results.xml
 ```
 
 Results appear in the workflow summary under the **Tests** tab.
 
----
-
-### GitLab CI
-
-```yaml
-keploy-test:
-  script:
-    - keploy test -c "<CMD_TO_RUN_APP>" --delay 10
-    - keploy report --format junit > test-results.xml
-  artifacts:
-    when: always
-    reports:
-      junit: test-results.xml
-```
-
-Results appear in the pipeline **Tests** tab.
-
----
-
-### Jenkins
-
-```groovy
-stage('Keploy Test') {
-  steps {
-    sh 'keploy test -c "<CMD_TO_RUN_APP>" --delay 10'
-    sh 'keploy report --format junit > test-results.xml'
-  }
-  post {
-    always {
-      junit 'test-results.xml'
-    }
-  }
-}
-```
-
-Results appear under **Test Results** in the build view with trend tracking across builds.
-
----
-
-### CircleCI
-
-```yaml
-- run:
-    name: Run Keploy Tests
-    command: keploy test -c "<CMD_TO_RUN_APP>" --delay 10
-
-- run:
-    name: Generate JUnit Report
-    command: keploy report --format junit > ~/test-results/keploy/results.xml
-
-- store_test_results:
-    path: ~/test-results
-```
-
-Results appear in the **Tests** tab of the pipeline run.

--- a/versioned_docs/version-4.0.0/running-keploy/cli-commands.md
+++ b/versioned_docs/version-4.0.0/running-keploy/cli-commands.md
@@ -34,7 +34,7 @@ Here are some examples of how to use some common flags:
 | `gen` (Deprecated) | `--sourceFilePath`, `--testFilePath`,`--coverageReportPath`,`--testCommand`,`--coverageFormat`,`--expectedCoverage`,`--maxIterations`,`--testDir`,`--llmBaseUrl`,`--model`,`--llmApiVersion`                                                                                                                                                                                               |
 | `normalize`        | `-p, --path`, `--test-run`, `--tests`                                                                                                                                                                                                                                                                                                                                                      |
 | `rerecord`         | `--test-sets`, `-t`                                                                                                                                                                                                                                                                                                                                                                        |
-| `report`           | `--test-sets, -t`, `-p, --path`, `--report-path, -r`, `--body`                                                                                                                                                                                                                                                                                                                             |
+| `report`           | `--test-sets, -t`, `-p, --path`, `--report-path, -r`, `--body` `--format` |                                                                                                                                                                                                                                                                                                                            |
 | `sanitize`         | `--test-sets, -t`, `-p, --path`                                                                                                                                                                                                                                                                                                                                                            |
 | `config`           | `--generate`,`-p, --path`                                                                                                                                                                                                                                                                                                                                                                  |
 
@@ -406,9 +406,20 @@ keploy report --summary
 ```bash
 keploy report --test-case "test-1"
 ```
+- `--format string` - Output format for the report. Accepted values: `text` (default), `junit`. When set to `junit`, outputs standard JUnit XML to stdout.
+```bash
+keploy report --format junit > test-results.xml
+```
 
-> **Notes**
->
+To scope the JUnit report to specific test-sets:
+```bash
+keploy report --format junit --test-sets "test-set-1"
+```
+
+See [JUnit XML Reports](/docs/keploy-cloud/junit-xml-reports) for CI integration examples.
+
+### Notes
+
 > - By default, `report` shows only **failed** tests with a compact, human-readable diff (status, headers—including trailers/content-length where applicable—and body changes).
 > - Use `--full` to see the complete expected vs actual bodies (with JSON colorization).
 > - `--summary` prints just the totals and a per–test-set table, optionally restricted with `-t/--test-sets`.

--- a/versioned_sidebars/version-4.0.0-sidebars.json
+++ b/versioned_sidebars/version-4.0.0-sidebars.json
@@ -30,6 +30,7 @@
         "running-keploy/keploy-templatize",
         "running-keploy/risk-profile-analysis",
         "keploy-cloud/time-freezing",
+        "keploy-cloud/junit-xml-reports",
         "keploy-cloud/mock-registry",
         "keploy-cloud/keploy-console",
         "keploy-cloud/auto-test-generation",


### PR DESCRIPTION
## What has changed?

Adds a new docs page — **JUnit XML Reports** — under Integration Testing in the sidebar (after Time Freezing).

The page covers:
- `--format junit` flag usage on `keploy report`
- JUnit XML output structure (test-sets → `<testsuite>`, failures → `<failure>`, obsolete → `<skipped>`)
- CI configuration examples for GitHub Actions, GitLab CI, Jenkins, and CircleCI

This documents the feature introduced in keploy/keploy#3955.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- Ran `npm run build` locally — no errors
- Verified page renders correctly at `localhost:3000/docs/keploy-cloud/junit-xml-reports`
- Confirmed sidebar entry appears after Time Freezing

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.