### PR TITLE
docs(public-api): add API docs URL alongside base URL

### DIFF
--- a/versioned_docs/version-4.0.0/running-keploy/public-api.md
+++ b/versioned_docs/version-4.0.0/running-keploy/public-api.md
@@ -29,6 +29,8 @@ The Keploy Public API gives you programmatic access to everything you can do in 
 
 **Base URL:** `https://api.keploy.io/client/v1`
 
+**API Docs:** [`https://api.keploy.io/client/v1/docs`](https://api.keploy.io/client/v1/docs)
+
 ---
 
 ## Authentication


### PR DESCRIPTION
## What has changed?

Adds a pointer to the interactive API reference (`https://api.keploy.io/client/v1/docs`) right below the **Base URL** on the Public REST API page, so readers can discover it without leaving the docs.

Updated file: `versioned_docs/version-4.0.0/running-keploy/public-api.md`

## Type of change

- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Local docs build preview — the new line renders as a clickable link directly under the existing **Base URL** entry. No other content on the page is affected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.