### PR TITLE
fix(ci): harden Submit docs URLs to IndexNow step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,19 @@ jobs:
           URL_COUNT=$(printf '%s\n' "$URLS" | wc -l | tr -d '[:space:]')
           echo "Submitting $URL_COUNT docs URLs to IndexNow"
 
-          JSON_URLS=$(printf '%s\n' "$URLS" | jq -R -s 'split("\n") | map(select(length > 0))')
+          # Explicit jq availability + payload-build checks: under
+          # `set -euo pipefail` a missing/failing jq would abort the step
+          # before the error/troubleshooting branches below could run,
+          # leaving an unannotated "process exited 1" in the Actions UI.
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::error::jq is required to build the IndexNow request payload. Install jq or use a runner image that includes it, then rerun this workflow."
+            exit 1
+          fi
+
+          if ! JSON_URLS=$(printf '%s\n' "$URLS" | jq -R -s 'split("\n") | map(select(length > 0))'); then
+            echo "::error::Failed to build the IndexNow JSON payload from the sitemap URL list. Inspect the URLs above for unexpected characters and rerun the workflow."
+            exit 1
+          fi
 
           # Capture curl exit status separately from HTTP code so network/DNS
           # failures are distinguishable from real non-2xx responses.
@@ -128,8 +140,8 @@ jobs:
           cat "$RESPONSE_FILE" 2>/dev/null || true
           echo ""
           echo "Troubleshooting:"
-          echo "  1. Verify key file is publicly reachable: curl -sS $INDEXNOW_KEY_LOC"
+          echo "  1. Verify key file is publicly reachable: curl -sS \"$INDEXNOW_KEY_LOC\""
           echo "  2. Reproduce request:"
-          echo "     curl -sS -X POST https://api.indexnow.org/indexnow -H 'Content-Type: application/json' \\"
+          echo "     curl -sS -X POST \"https://api.indexnow.org/indexnow\" -H 'Content-Type: application/json' \\"
           echo "       -d '{\"host\":\"${INDEXNOW_HOST}\",\"key\":\"${INDEXNOW_KEY}\",\"keyLocation\":\"${INDEXNOW_KEY_LOC}\",\"urlList\":[\"https://${INDEXNOW_HOST}/docs/\"]}'"
           exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,17 +80,19 @@ jobs:
             exit 0
           fi
 
-          # Filter to the current (unversioned) docs only:
+          # Filter the sitemap URL list:
           # - drop auto-generated /tags/ pages (low-value for search indexing)
-          # - drop legacy versioned docs (/docs/1.0.0/, 2.0.0/, 3.0.0/) to keep
-          #   submissions focused on the preferred current doc paths
+          # - drop any versioned doc path like /docs/N.M.P/ so only the
+          #   current (unversioned) docs are submitted. Matching any numeric
+          #   major-minor-patch prefix keeps the rule correct when a future
+          #   v5/v6 archive lands alongside today's v1-v3 legacy versions.
           #
           # `|| true` makes the pipeline non-fatal under `set -euo pipefail`:
           # if every URL happens to be filtered out, grep returns 1, which
           # would otherwise abort the step before the empty-result check below.
           URLS=$(grep -oP '<loc>\K[^<]+' "$SITEMAP" \
             | grep -v '/tags/' \
-            | grep -vE '/docs/(1|2|3)\.[0-9]+\.[0-9]+/' \
+            | grep -vE '/docs/[0-9]+\.[0-9]+\.[0-9]+/' \
             | sort -u || true)
 
           if [ -z "$URLS" ]; then
@@ -100,6 +102,12 @@ jobs:
 
           URL_COUNT=$(printf '%s\n' "$URLS" | wc -l | tr -d '[:space:]')
           echo "Submitting $URL_COUNT docs URLs to IndexNow"
+
+          # Log a small sample so jq/curl failures below have enough context
+          # to debug from the log alone (otherwise the only artifact is a
+          # count, and the operator can't tell which URL broke the payload).
+          echo "First 5 URLs:"
+          printf '%s\n' "$URLS" | head -5 | sed 's/^/  /'
 
           # Explicit jq availability + payload-build checks: under
           # `set -euo pipefail` a missing/failing jq would abort the step
@@ -111,7 +119,7 @@ jobs:
           fi
 
           if ! JSON_URLS=$(printf '%s\n' "$URLS" | jq -R -s 'split("\n") | map(select(length > 0))'); then
-            echo "::error::Failed to build the IndexNow JSON payload from the sitemap URL list. Inspect the URLs above for unexpected characters and rerun the workflow."
+            echo "::error::Failed to build the IndexNow JSON payload from the sitemap URL list. See the 'First 5 URLs' sample logged above for unexpected characters, then rerun the workflow."
             exit 1
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,25 +66,35 @@ jobs:
 
           INDEXNOW_KEY_LOC="https://${INDEXNOW_HOST}/${INDEXNOW_KEY}.txt"
 
+          # Unique temp file for the IndexNow response body; cleaned up on
+          # every exit path via trap so stale data can't leak into future
+          # reads and repeat runs of this step don't collide.
+          RESPONSE_FILE=$(mktemp)
+          trap 'rm -f "$RESPONSE_FILE"' EXIT
+
           # Use the just-built sitemap so URLs are guaranteed to exist on the
           # deployed site (the previous S3 sync step pushed it up moments ago).
           SITEMAP="build/docs/sitemap.xml"
           if [ ! -f "$SITEMAP" ]; then
-            echo "::warning::Sitemap not found at $SITEMAP, skipping IndexNow submission"
+            echo "::notice::Sitemap not found at $SITEMAP, skipping IndexNow submission"
             exit 0
           fi
 
           # Filter to the current (unversioned) docs only:
           # - drop auto-generated /tags/ pages (low-value for search indexing)
-          # - drop legacy versioned docs (/docs/1.0.0/, 2.0.0/, 3.0.0/) since
-          #   robots.txt disallows them and they're marked noindex anyway
+          # - drop legacy versioned docs (/docs/1.0.0/, 2.0.0/, 3.0.0/) to keep
+          #   submissions focused on the preferred current doc paths
+          #
+          # `|| true` makes the pipeline non-fatal under `set -euo pipefail`:
+          # if every URL happens to be filtered out, grep returns 1, which
+          # would otherwise abort the step before the empty-result check below.
           URLS=$(grep -oP '<loc>\K[^<]+' "$SITEMAP" \
             | grep -v '/tags/' \
             | grep -vE '/docs/(1|2|3)\.[0-9]+\.[0-9]+/' \
-            | sort -u)
+            | sort -u || true)
 
           if [ -z "$URLS" ]; then
-            echo "::warning::No current-version docs URLs parsed from $SITEMAP, skipping"
+            echo "::notice::No current-version docs URLs parsed from $SITEMAP, skipping"
             exit 0
           fi
 
@@ -96,7 +106,7 @@ jobs:
           # Capture curl exit status separately from HTTP code so network/DNS
           # failures are distinguishable from real non-2xx responses.
           CURL_EXIT=0
-          HTTP_CODE=$(curl -sS -o /tmp/indexnow-resp.txt -w "%{http_code}" \
+          HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" \
             -X POST "https://api.indexnow.org/indexnow" \
             -H "Content-Type: application/json" \
             -d "{\"host\":\"${INDEXNOW_HOST}\",\"key\":\"${INDEXNOW_KEY}\",\"keyLocation\":\"${INDEXNOW_KEY_LOC}\",\"urlList\":${JSON_URLS}}") || CURL_EXIT=$?
@@ -115,7 +125,7 @@ jobs:
           fi
 
           echo "::error::IndexNow returned HTTP $HTTP_CODE. Response body:"
-          cat /tmp/indexnow-resp.txt 2>/dev/null || true
+          cat "$RESPONSE_FILE" 2>/dev/null || true
           echo ""
           echo "Troubleshooting:"
           echo "  1. Verify key file is publicly reachable: curl -sS $INDEXNOW_KEY_LOC"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,43 +56,70 @@ jobs:
 
       - name: Submit docs URLs to IndexNow
         env:
-          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+          INDEXNOW_HOST: keploy.io
+          # The default key is the one served from keploy.io/<key>.txt by the
+          # landing repo; override via a repo secret only if rotating.
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY || 'feeeddbe661a4686ba6e4d5cb663b2cb' }}
         continue-on-error: true
         run: |
-          # Use the built sitemap as the source of truth for URLs.
+          set -euo pipefail
+
+          INDEXNOW_KEY_LOC="https://${INDEXNOW_HOST}/${INDEXNOW_KEY}.txt"
+
+          # Use the just-built sitemap so URLs are guaranteed to exist on the
+          # deployed site (the previous S3 sync step pushed it up moments ago).
           SITEMAP="build/docs/sitemap.xml"
           if [ ! -f "$SITEMAP" ]; then
-            echo "Sitemap not found at $SITEMAP, skipping IndexNow"
+            echo "::warning::Sitemap not found at $SITEMAP, skipping IndexNow submission"
             exit 0
           fi
 
-          URLS=$(grep -oP '<loc>\K[^<]+' "$SITEMAP" || true)
+          # Filter to the current (unversioned) docs only:
+          # - drop auto-generated /tags/ pages (low-value for search indexing)
+          # - drop legacy versioned docs (/docs/1.0.0/, 2.0.0/, 3.0.0/) since
+          #   robots.txt disallows them and they're marked noindex anyway
+          URLS=$(grep -oP '<loc>\K[^<]+' "$SITEMAP" \
+            | grep -v '/tags/' \
+            | grep -vE '/docs/(1|2|3)\.[0-9]+\.[0-9]+/' \
+            | sort -u)
 
           if [ -z "$URLS" ]; then
-            echo "No URLs found in sitemap, skipping"
+            echo "::warning::No current-version docs URLs parsed from $SITEMAP, skipping"
             exit 0
           fi
 
-          URL_COUNT=$(echo "$URLS" | wc -l)
+          URL_COUNT=$(printf '%s\n' "$URLS" | wc -l | tr -d '[:space:]')
           echo "Submitting $URL_COUNT docs URLs to IndexNow"
 
-          KEY="${INDEXNOW_KEY:-9ded60b43b8b40578588fc42b04c3e5d}"
-          JSON_URLS=$(echo "$URLS" | jq -R -s 'split("\n") | map(select(length > 0))' || true)
+          JSON_URLS=$(printf '%s\n' "$URLS" | jq -R -s 'split("\n") | map(select(length > 0))')
 
-          if [ -z "$JSON_URLS" ]; then
-            echo "Failed to build JSON URL list, skipping"
+          # Capture curl exit status separately from HTTP code so network/DNS
+          # failures are distinguishable from real non-2xx responses.
+          CURL_EXIT=0
+          HTTP_CODE=$(curl -sS -o /tmp/indexnow-resp.txt -w "%{http_code}" \
+            -X POST "https://api.indexnow.org/indexnow" \
+            -H "Content-Type: application/json" \
+            -d "{\"host\":\"${INDEXNOW_HOST}\",\"key\":\"${INDEXNOW_KEY}\",\"keyLocation\":\"${INDEXNOW_KEY_LOC}\",\"urlList\":${JSON_URLS}}") || CURL_EXIT=$?
+
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "::error::IndexNow request failed to execute (curl exit $CURL_EXIT)."
+            echo "  Check connectivity: curl -I https://api.indexnow.org/"
+            exit 1
+          fi
+
+          # IndexNow returns 200 for processed and 202 for accepted-pending-
+          # verification; both are success per the spec.
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            echo "Submitted $URL_COUNT URLs to IndexNow (HTTP $HTTP_CODE)"
             exit 0
           fi
 
-          RESPONSE_FILE=$(mktemp)
-          HTTP_CODE=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" -X POST "https://api.indexnow.org/indexnow" \
-            -H "Content-Type: application/json" \
-            -d "{\"host\":\"keploy.io\",\"key\":\"$KEY\",\"urlList\":$JSON_URLS}" || echo "000")
-
-          echo "IndexNow response: $HTTP_CODE"
-          if [ "$HTTP_CODE" -ge 400 ] || [ "$HTTP_CODE" = "000" ]; then
-            echo "IndexNow submission failed (HTTP $HTTP_CODE) — will not block deployment."
-            echo "Verify the key file is hosted at https://keploy.io/${KEY}.txt"
-            cat "$RESPONSE_FILE" 2>/dev/null || true
-          fi
-          rm -f "$RESPONSE_FILE"
+          echo "::error::IndexNow returned HTTP $HTTP_CODE. Response body:"
+          cat /tmp/indexnow-resp.txt 2>/dev/null || true
+          echo ""
+          echo "Troubleshooting:"
+          echo "  1. Verify key file is publicly reachable: curl -sS $INDEXNOW_KEY_LOC"
+          echo "  2. Reproduce request:"
+          echo "     curl -sS -X POST https://api.indexnow.org/indexnow -H 'Content-Type: application/json' \\"
+          echo "       -d '{\"host\":\"${INDEXNOW_HOST}\",\"key\":\"${INDEXNOW_KEY}\",\"keyLocation\":\"${INDEXNOW_KEY_LOC}\",\"urlList\":[\"https://${INDEXNOW_HOST}/docs/\"]}'"
+          exit 1


### PR DESCRIPTION
## Summary

Three functional bugs in the existing `Submit docs URLs to IndexNow` step in `main.yml` have been silently broken since #827 landed:

1. **Hardcoded fallback key is stale**: `${INDEXNOW_KEY:-9ded60b43b8b40578588fc42b04c3e5d}`. That key was deleted from `landing/public/` in keploy/landing#186 because Bing was rejecting it with `HTTP 403 UserForbiddedToAccessSite`. Every push-run of `main.yml` since #827 has been hitting 403 in silence. Reproduced just now:
   ```
   curl -sS -X POST https://api.indexnow.org/indexnow \
     -H 'Content-Type: application/json' \
     -d '{"host":"keploy.io","key":"9ded60b43b8b40578588fc42b04c3e5d",...}'
   {"errorCode":"UserForbiddedToAccessSite",...}
   HTTP 403
   ```
2. **`continue-on-error: true` + no `::error::` annotation + no `exit 1`** meant the failure was completely invisible. Step went green, no alerting.
3. **No URL filtering**: the sitemap contains ~800 entries including 412 auto-generated `/tags/` pages and 184 legacy `/docs/{1,2,3}.0.0/` pages (which `robots.txt` already disallows). Only ~206 are current-version docs worth submitting.

## Changes
- Default `INDEXNOW_KEY` to `feeeddbe661a4686ba6e4d5cb663b2cb` — the key actually served from `keploy.io/<key>.txt`. The `secrets.INDEXNOW_KEY` override still takes priority for rotations.
- Add `keyLocation` to the payload.
- Filter sitemap URLs: drop `/tags/` pages and legacy `/docs/{1,2,3}.0.0/` paths before submitting. Reduces submission from ~800 → ~206, all on currently-supported paths.
- `set -euo pipefail`, capture `CURL_EXIT` separately from `HTTP_CODE`, exit non-zero with `::error::` on real failure (curl exit != 0 or HTTP non-2xx), print response body plus a Troubleshooting block containing a `keyLocation` check and a ready-to-paste POST reproducer. `2xx` (including `202 accepted-pending-verification`) is an explicit `exit 0`.
- Keep `continue-on-error: true` so a failure never blocks the deploy, but `::error::` annotations now surface failures in the Actions UI instead of hiding them.

Also mirrors the hardening pattern already shipped in [keploy/blog-website#366](https://github.com/keploy/blog-website/pull/366).

## Test plan
- [x] Dry-ran the filter locally against the live `docs/sitemap.xml` (after gunzip) → 206 current-version URLs, 0 tag pages, 0 legacy version pages
- [x] Submitted a real 20-URL POST to `https://api.indexnow.org/indexnow` with the new key + `keyLocation` → **HTTP 200**
- [x] Verified YAML parses cleanly
- [x] `INDEXNOW_KEY` secret already set on `keploy/docs` (separate, so Option A from the diagnosis is in effect right now — the next `main.yml` run should hit HTTP 200 even before this PR merges)
- [ ] Merge and confirm the next push-run on `main.yml` logs `Submitted <N> URLs to IndexNow (HTTP 200)` instead of silently 403'ing
- [ ] Bing Webmaster Tools → IndexNow tab should show the new submission within ~24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)