### PR TITLE
docs: clarify how to rename a Test-Set

### DIFF
--- a/versioned_docs/version-4.0.0/running-keploy/rename-testcases.md
+++ b/versioned_docs/version-4.0.0/running-keploy/rename-testcases.md
@@ -54,4 +54,14 @@ curl --request POST \
 
 ## Rename Test-Sets
 
-To rename your test set, you can manually override the default name from `test-set-0` to a `kTest-0` in the `keploy` folder.
+To rename a Test-Set, rename its folder directly inside the `keploy/` directory. For example, rename `test-set-0` to `checkout-flow`. Keploy discovers Test-Sets by listing every subdirectory of `keploy/`, so any name works.
+
+The only names to avoid are the reserved folders that Keploy itself writes to: `reports`, `testReports`, and `schema`.
+
+Once renamed, pass the new name to `--test-sets` (or `-t`) when you run `keploy test`:
+
+```bash
+keploy test -c "<your app cmd>" -t "checkout-flow"
+```
+
+Report files generated before the rename keep the old Test-Set name in their filenames under `keploy/reports/test-run-*/`. Runs after the rename use the new name.


### PR DESCRIPTION
## What has changed?

The **Rename Test-Sets** section on `versioned_docs/version-4.0.0/running-keploy/rename-testcases.md` was a single sentence that told users they could rename `test-set-0`, but didn't explain:

- Why Keploy accepts the rename (folder-based discovery — no `test-set-` prefix filter).
- Which folder names are reserved (`reports`, `testReports`, `schema`).
- How to reference the renamed Test-Set at replay time (`-t` / `--test-sets`).
- That pre-existing report files keep the old Test-Set name.

This PR expands the section to cover all four points, verified against `pkg/platform/yaml/yaml.go:ReadSessionIndices` in `keploy/keploy`.

This PR Resolves keploy/keploy#4069

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Prose-only change. Verified locally:

- `vale versioned_docs/version-4.0.0/running-keploy/rename-testcases.md` — 0 errors on changed lines (`filter_mode: diff_context` in CI skips the two pre-existing frontmatter/example errors on unchanged lines).
- `npx prettier@2.8.8 --check versioned_docs/version-4.0.0/running-keploy/rename-testcases.md` — clean.
- No frontmatter, sidebar, or admonition changes, so the Docusaurus build surface is unchanged.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->