### PR TITLE
docs: update GSoC contribution guide from 2023 to 2026

### DIFF
--- a/docs/gsoc/contribution-guide.md
+++ b/docs/gsoc/contribution-guide.md
@@ -16,11 +16,10 @@ toc_max_heading_level: 2
 
 ### Welcome to Google Summer of Code
 
-[Google Summer of Code](https://summerofcode.withgoogle.com/) is a 16 years old program, run every summer, with the intention of bringing more students into open source.
-
+[Google Summer of Code](https://summerofcode.withgoogle.com/) is a 20+ years old program, run every summer, with the intention of bringing more students into open source.
 Open source projects apply as mentor organizations and if they are accepted, students send proposals to them to work on a few months' long project. Projects can be planned out by the organizations in advance or can be proposed by students.
 
-Google pays the students, not the organizations they work with. Beginning in 2023, Google is opening the program up to all newcomers of open source that are 18 years and older.
+Google pays the students, not the organizations they work with. Beginning in 2024, Google opened the program up to all newcomers of open source that are 18 years and older.
 
 You can read more about the format of the program and its goals [here](https://google.github.io/gsocguides/mentor/).
 
@@ -37,103 +36,23 @@ Keploy is looking for motivated students who are passionate about open source so
 To get started with GSoC and Keploy, follow these steps:
 
 1. If you are new to Keploy, try setting up Keploy in your local machine and running one (or more) of the sample applications. You can refer the [docs](#docs).
-2. You can then check out the [projects](#projects) that are selected for GSoC 2023 and try completing the tasks in the task list. Remember, the tasks will act as a selection criteria for shortlisting candidates.
-3. You can connect with the mentors over slack to clear any of your doubts.
+2. You can then check out the [projects](https://github.com/keploy/gsoc) that are selected for the current GSoC year and try completing the tasks in the task list. Remember, the tasks will act as a selection criteria for shortlisting candidates.
+3. You can connect with the mentors over Slack to clear any of your doubts.
 4. Submit your proposal and that's it!
 
-## Projects in GSoC 2023
+## Projects in GSoC 2026
 
-<table>
-  <tr>
-    <td>Project Title</td>
-    <td>Ideas List</td>
-    <td>Project Link</td>
-  </tr>
-  <tr>
-    <td>Keploy CLI Refactoring</td>
-    <td><a href="https://github.com/keploy/gsoc/tree/main/2023#1-keploy-cli-refactoring" alt='Idea List'>Ideas</a></td>
-    <td ><a style={{display:"flex",justifyContent:"center",alignItems:"center"}} href="https://github.com/keploy/keploy"  alt="project link">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
-        <path d="M12 .3c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.8 8.205 11.385.6.11.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.746.083-.73.083-.73 1.205.085 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.304 3.495.997.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.385 1.236-3.22-.135-.302-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.874.12 3.176.765.835 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.215 0 1.604-.015 2.894-.015 3.284 0 .315.21.688.825.576 4.77-1.585 8.205-6.086 8.205-11.385 0-6.63-5.37-12-12-12z"/>
-</svg>
-</a></td>
-  </tr>
-  <tr>
-    <td>Keploy Java SDK</td>
-    <td><a href="https://github.com/keploy/gsoc/tree/main/2023#2-keploy-java-sdk" alt="Ideas Lst">Ideas</a></td>
-    <td><a style={{display:"flex",justifyContent:"center",alignItems:"center"}} href="https://github.com/keploy/java-sdk"  alt="project link">
-       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
-        <path d="M12 .3c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.8 8.205 11.385.6.11.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.746.083-.73.083-.73 1.205.085 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.304 3.495.997.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.385 1.236-3.22-.135-.302-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.874.12 3.176.765.835 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.215 0 1.604-.015 2.894-.015 3.284 0 .315.21.688.825.576 4.77-1.585 8.205-6.086 8.205-11.385 0-6.63-5.37-12-12-12z"/>
-</svg> 
-    </a></td>
-  </tr>
-  <tr>
-    <td>Keploy Typescript/Javascript SDK</td>
-    <td><a href="https://github.com/keploy/gsoc/tree/main/2023#3-keploy-typescriptjavascript-sdk" alt="Ideas Lst">Ideas</a></td>
-    <td><a style={{display:"flex",justifyContent:"center",alignItems:"center"}} href="https://github.com/keploy/typescript-sdk"  alt="project link">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
-        <path d="M12 .3c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.8 8.205 11.385.6.11.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.746.083-.73.083-.73 1.205.085 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.304 3.495.997.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.385 1.236-3.22-.135-.302-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.874.12 3.176.765.835 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.215 0 1.604-.015 2.894-.015 3.284 0 .315.21.688.825.576 4.77-1.585 8.205-6.086 8.205-11.385 0-6.63-5.37-12-12-12z"/>
-</svg>
-    </a></td>
-  </tr>
-  <tr>
-    <td>Autogenerate Test Cases</td>
-    <td><a href="https://github.com/keploy/gsoc/tree/main/2023#3-keploy-typescriptjavascript-sdk" alt="Ideas Lst">Ideas</a></td>
-    <td><a style={{display:"flex",justifyContent:"center",alignItems:"center"}} href="https://github.com/keploy/keploy/issues/24"  alt="project link">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
-        <path d="M12 .3c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.8 8.205 11.385.6.11.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.746.083-.73.083-.73 1.205.085 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.304 3.495.997.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.385 1.236-3.22-.135-.302-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.874.12 3.176.765.835 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.215 0 1.604-.015 2.894-.015 3.284 0 .315.21.688.825.576 4.77-1.585 8.205-6.086 8.205-11.385 0-6.63-5.37-12-12-12z"/>
-</svg></a></td>
-  </tr>
-  <tr>
-    <td>eBPF based Keploy Integration</td>
-    <td><a href="https://github.com/keploy/gsoc/tree/main/2023#5-ebpf-based-keploy-integration" alt="Ideas Lst">Ideas</a></td>
-    <td><a style={{display:"flex",justifyContent:"center",alignItems:"center"}} href="https://github.com/keploy/keploy"  alt="project link">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
-        <path d="M12 .3c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.8 8.205 11.385.6.11.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.746.083-.73.083-.73 1.205.085 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.304 3.495.997.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.385 1.236-3.22-.135-.302-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.874.12 3.176.765.835 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.215 0 1.604-.015 2.894-.015 3.284 0 .315.21.688.825.576 4.77-1.585 8.205-6.086 8.205-11.385 0-6.63-5.37-12-12-12z"/>
-</svg></a></td>
-  </tr>
-  <tr>
-    <td>JS or Go based DSL for Keploy</td>
-    <td><a href="https://github.com/keploy/gsoc/tree/main/2023#6-js-or-go-based-dsl-for-keploy" alt="Ideas Lst">Ideas</a></td>
-    <td><a style={{display:"flex",justifyContent:"center",alignItems:"center"}} href="https://github.com/keploy/keploy"  alt="project link">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24px" height="24px">
-        <path d="M12 .3c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.8 8.205 11.385.6.11.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.746.083-.73.083-.73 1.205.085 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.304 3.495.997.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.385 1.236-3.22-.135-.302-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.874.12 3.176.765.835 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.215 0 1.604-.015 2.894-.015 3.284 0 .315.21.688.825.576 4.77-1.585 8.205-6.086 8.205-11.385 0-6.63-5.37-12-12-12z"/>
-</svg></a></td>
-  </tr>
-</table>
-
-<!-- ## Code Contribution Guidelines
-
-When contributing to a Keploy project, please follow these guidelines:
-
-- Fork the repository and create a new branch for your work.
-- Write clear and concise commit messages.
-- Follow the project's coding style and conventions.
-- Write tests for your code and ensure they pass.
-- Create a pull request and describe your changes in detail.
-
-## Non-Code Contribution Guidelines
-
-Non-code contributions to a Keploy project are also valuable. Some examples of non-code contributions include:
-
-- Documentation: improving project documentation or writing new documentation.
-- Translation: translating project documentation or software into a different language.
-- Outreach: helping to promote the project to a wider audience.
-- Design: creating logos, icons, or other design elements for the project.
-
-If you are interested in making a non-code contribution to a Keploy project, please reach out to the project mentors to discuss how you can best contribute. -->
+For the current year's project ideas, visit the [Keploy GSoC repository](https://github.com/keploy/gsoc).
 
 ## Timeline
 
-| Important events                                                                   | Deadline                        |
-| ---------------------------------------------------------------------------------- | ------------------------------- |
-| Organization Applications Open                                                     | January 23, 2023                |
-| Organization Application Deadline                                                  | February 7, 2023                |
-| Organizations Announced                                                            | February 22, 2023               |
-| Potential GSoC contributors discuss application ideas with mentoring organizations | February 22 - March 20, 2023    |
-| GSoC contributor application period                                                | March 20 - April 4, 2023        |
-| Accepted GSoC Contributor projects announced                                       | May 4, 2023                     |
-| Students work on their Google Summer of Code project                               | May 4, 2023 - November 17, 2023 |
+| Important events                                                                   | Deadline                     |
+| ---------------------------------------------------------------------------------- | ---------------------------- |
+| Organization Applications Open                                                     | January 2026                 |
+| Organizations Announced                                                            | February 19, 2026            |
+| Contributor Application Period                                                     | March 16 - March 31, 2026    |
+| Accepted GSoC Contributors Announced                                               | April 30, 2026               |
+| GSoC Coding Period                                                                 | May - August 2026            |
 
 ## Conclusion
 


### PR DESCRIPTION
## What changed
- Updated GSoC program age from "16 years" to "20+ years"
- Fixed newcomer eligibility year from 2023 to 2024
- Updated project references to point to live GSoC repo instead of hardcoded 2023 projects
- Replaced broken 2023 project table with a clean link to current GSoC repo
- Updated timeline table from 2023 dates to 2026 dates

## Why
The GSoC contribution guide was outdated by 3 years, showing stale project listings and incorrect timeline dates that would mislead new contributors.