### PR TITLE
feat: add announcement bar with updated gittogether details

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -224,7 +224,8 @@ module.exports = {
     },
     announcementBar: {
       id: "announcementBar_gittogether_sf_2026", // Increment on change to reset dismissed state
-      content: "GitTogether SF — May 14, 2026 — Register Now",
+      content: "GitTogether SF • May 14, 2026 • San Francisco",
+      isCloseable: true,
     },
     prism: {
       theme: prismThemes.vsLight,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -223,8 +223,8 @@ module.exports = {
       // },
     },
     announcementBar: {
-      id: "announcementBar_1", // Increment on change
-      content: `⭐️ If you like Keploy, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/keploy/keploy">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/keployio">Twitter</a> ❤️ `,
+      id: "announcementBar_gittogether_sf_2026", // Increment on change to reset dismissed state
+      content: "GitTogether SF — May 14, 2026 — Register Now",
     },
     prism: {
       theme: prismThemes.vsLight,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -98,12 +98,14 @@ body {
   max-width: 100vw;
 }
 
-/* Navbar - always full viewport width */
+/* Navbar - always full viewport width, sticks below the announcement bar */
 .navbar {
   width: 100vw !important;
   max-width: 100vw !important;
   left: 0;
   right: 0;
+  position: sticky !important;
+  top: var(--docusaurus-announcement-bar-height, 0px) !important;
 }
 
 .navbar__inner {
@@ -860,49 +862,13 @@ td img {
   background-size: 24px 24px;
 }
 
-/* Announcement bar - striped orange styling (top-level container only) */
-div[class*="announcementBar"]:not([class*="Content"]):not([class*="Close"]) {
-  background: repeating-linear-gradient(
-    135deg,
-    rgba(255, 145, 77, 0.15),
-    rgba(255, 145, 77, 0.15) 10px,
-    rgba(255, 145, 77, 0.05) 10px,
-    rgba(255, 145, 77, 0.05) 20px
-  ) !important;
-  font-weight: 600;
-  font-size: 0.875rem;
-  padding: 0.5rem 0;
+/* Announcement bar - custom marquee implementation.
+   Strip all Docusaurus default styles so our Tailwind component renders cleanly. */
+div[class*="announcementBar"] {
+  background: none !important;
+  padding: 0 !important;
   border: none !important;
-  border-bottom: 1px solid rgba(255, 145, 77, 0.2) !important;
-  color: #00163d !important;
-}
-
-div[class*="announcementBar"] a {
-  color: #c45a1a !important;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  font-weight: 700;
-}
-
-div[class*="announcementBar"] a:hover {
-  color: #a0460f !important;
-}
-
-html[data-theme="dark"]
-  div[class*="announcementBar"]:not([class*="Content"]):not([class*="Close"]) {
-  background: repeating-linear-gradient(
-    135deg,
-    rgba(255, 145, 77, 0.12),
-    rgba(255, 145, 77, 0.12) 10px,
-    rgba(255, 145, 77, 0.04) 10px,
-    rgba(255, 145, 77, 0.04) 20px
-  ) !important;
-  color: #f3f4f6 !important;
-  border-bottom-color: rgba(255, 145, 77, 0.15) !important;
-}
-
-html[data-theme="dark"] div[class*="announcementBar"] a {
-  color: #ff914d !important;
+  color: inherit !important;
 }
 
 .list-disc > a {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -98,6 +98,13 @@ body {
   max-width: 100vw;
 }
 
+:root {
+  --keploy-header-offset: calc(
+    var(--docusaurus-announcement-bar-height, 0px) +
+      var(--ifm-navbar-height, 0px)
+  );
+}
+
 /* Navbar - always full viewport width, sticks below the announcement bar */
 .navbar {
   width: 100vw !important;
@@ -864,6 +871,7 @@ td img {
 
 /* Announcement bar - custom marquee implementation.
    Strip all Docusaurus default styles so our Tailwind component renders cleanly. */
+.keploy-announcement-bar,
 div[class*="announcementBar"] {
   background: none !important;
   padding: 0 !important;
@@ -1485,7 +1493,6 @@ main .container {
 
 /* Docusaurus specific wrappers */
 .docusaurus-mt-lg,
-
 .docs-doc-page,
 [class*="docsWrapper"] {
   max-width: 100% !important;
@@ -2193,7 +2200,7 @@ html[data-theme="dark"] .table-of-contents__link--active {
 /* Sticky breadcrumbs wrapper */
 nav[class*="theme-doc-breadcrumb"] {
   position: sticky !important;
-  top: var(--ifm-navbar-height, 0px) !important;
+  top: var(--keploy-header-offset) !important;
   z-index: 10 !important;
   background: #ffffff !important;
   margin-top: 0 !important;
@@ -2678,7 +2685,7 @@ html[data-theme="dark"]
   }
 
   main[class*="docMainContainer"] {
-  padding-top: 0 !important;
+    padding-top: 0 !important;
     max-width: 100%;
   }
 
@@ -3123,7 +3130,6 @@ html[data-theme="dark"] .docs-inline-footer__slack {
 
 /* ===== MOBILE FIX FOR PREV / NEXT CARDS ===== */
 @media (max-width: 768px) {
-
   .pagination-nav {
     display: flex !important;
     flex-direction: column !important; /* stack vertically */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -871,9 +871,13 @@ td img {
 
 /* Announcement bar - custom marquee implementation.
    Strip all Docusaurus default styles so our Tailwind component renders cleanly. */
-.keploy-announcement-bar,
-div[class*="announcementBar"] {
-  background: none !important;
+.keploy-announcement-bar {
+  padding: 0 !important;
+  color: inherit !important;
+}
+
+div[class*="announcementBar"]:not(.keploy-announcement-bar) {
+  background-color: transparent !important;
   padding: 0 !important;
   border: none !important;
   color: inherit !important;

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useRef, useState} from "react";
 import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import {useThemeConfig} from "@docusaurus/theme-common";
 import {useAnnouncementBar} from "@docusaurus/theme-common/internal";
 import {ArrowRight, X} from "lucide-react";
@@ -47,9 +48,9 @@ function MarqueeContent({content}) {
 
   return (
     <>
-      {items.map((item) => (
+      {items.map((item, index) => (
         <span
-          key={item}
+          key={`announcement-item-${index}`}
           style={{whiteSpace: "nowrap"}}
           className="inline-flex items-center gap-3 text-[12px] text-[#23120a] sm:text-[13px] lg:text-[14px]"
         >
@@ -85,6 +86,7 @@ export default function AnnouncementBar() {
     announcementBar?.content || "GitTogether SF • May 14, 2026 • San Francisco"
   );
   const isCloseable = announcementBar?.isCloseable !== false;
+  const backgroundImageUrl = useBaseUrl("/img/GitTogether.jpg");
 
   useEffect(() => {
     if (!isActive || !containerRef.current) {
@@ -227,14 +229,13 @@ export default function AnnouncementBar() {
       ref={containerRef}
       role="banner"
       aria-label="Event announcement"
-      className="sticky top-0 z-[100] border-b border-white/40 bg-cover bg-center bg-no-repeat shadow-[0_12px_30px_rgba(234,88,12,0.16)] backdrop-blur"
+      className="announcementBar keploy-announcement-bar sticky top-0 z-[100] border-b border-white/40 bg-cover bg-center bg-no-repeat shadow-[0_12px_30px_rgba(234,88,12,0.16)] backdrop-blur"
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
       style={{
-        backgroundImage:
-          "url('https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp')",
+        backgroundImage: `url('${backgroundImageUrl}')`,
         transform: dismissing ? "translateY(-110%)" : undefined,
         opacity: dismissing ? 0 : undefined,
         transition: dismissing
@@ -250,12 +251,17 @@ export default function AnnouncementBar() {
       <div className="relative mx-auto max-w-[1440px] px-3 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
         {/* Mobile: single row with marquee, dismiss control, and compact CTA. */}
         <div className="flex min-w-0 items-center gap-2 lg:hidden">
-          <div
+          <Link
+            to={ANNOUNCEMENT.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open the GitTogether SF registration page"
             onMouseEnter={() => setIsMarqueePaused(true)}
             onMouseLeave={() => setIsMarqueePaused(false)}
             onPointerEnter={() => setIsMarqueePaused(true)}
             onPointerLeave={() => setIsMarqueePaused(false)}
-            className="min-w-0 flex-1 overflow-hidden"
+            className="min-w-0 flex-1 overflow-hidden no-underline"
+            style={{textDecoration: "none"}}
           >
             <MarqueeTrack
               paused={isMarqueePaused}
@@ -265,7 +271,7 @@ export default function AnnouncementBar() {
             >
               <MarqueeContent content={marqueeContent} />
             </MarqueeTrack>
-          </div>
+          </Link>
 
           {isCloseable && (
             <button
@@ -302,8 +308,13 @@ export default function AnnouncementBar() {
             {ANNOUNCEMENT.eyebrow}
           </span>
 
-          <div
-            className="min-w-0 flex-1 overflow-hidden"
+          <Link
+            to={ANNOUNCEMENT.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open the GitTogether SF registration page"
+            className="min-w-0 flex-1 overflow-hidden no-underline"
+            style={{textDecoration: "none"}}
             onMouseEnter={() => setIsMarqueePaused(true)}
             onMouseLeave={() => setIsMarqueePaused(false)}
             onPointerEnter={() => setIsMarqueePaused(true)}
@@ -317,7 +328,7 @@ export default function AnnouncementBar() {
             >
               <MarqueeContent content={marqueeContent} />
             </MarqueeTrack>
-          </div>
+          </Link>
 
           <Link
             to={ANNOUNCEMENT.href}

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -256,8 +256,6 @@ export default function AnnouncementBar() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Open the GitTogether SF registration page"
-            onMouseEnter={() => setIsMarqueePaused(true)}
-            onMouseLeave={() => setIsMarqueePaused(false)}
             onPointerEnter={() => setIsMarqueePaused(true)}
             onPointerLeave={() => setIsMarqueePaused(false)}
             className="min-w-0 flex-1 overflow-hidden no-underline"
@@ -315,8 +313,6 @@ export default function AnnouncementBar() {
             aria-label="Open the GitTogether SF registration page"
             className="min-w-0 flex-1 overflow-hidden no-underline"
             style={{textDecoration: "none"}}
-            onMouseEnter={() => setIsMarqueePaused(true)}
-            onMouseLeave={() => setIsMarqueePaused(false)}
             onPointerEnter={() => setIsMarqueePaused(true)}
             onPointerLeave={() => setIsMarqueePaused(false)}
           >

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -1,0 +1,222 @@
+import React, { useState, useRef, useEffect } from "react";
+import Link from "@docusaurus/Link";
+import { ArrowRight, X } from "lucide-react";
+
+const ANNOUNCEMENT = {
+  eyebrow: "Event Live",
+  href: "https://luma.com/lr79szro",
+  ctaLabel: "Register Now",
+};
+
+function MarqueeTrack({ paused, children, repeat = 10, duration, gap }) {
+  return (
+    <div
+      className="group flex overflow-hidden [gap:var(--gap)]"
+      style={{ "--duration": duration, "--gap": gap }}
+    >
+      {Array(repeat)
+        .fill(0)
+        .map((_, i) => (
+          <div
+            key={i}
+            className="flex shrink-0 flex-row justify-around [gap:var(--gap)] animate-marquee"
+            style={{ animationPlayState: paused ? "paused" : "running" }}
+          >
+            {children}
+          </div>
+        ))}
+    </div>
+  );
+}
+
+function MarqueeContent() {
+  const items = [
+    "Keploy is hosting a community meetup in San Francisco!",
+    "GitTogether SF • May 14, 2026 • San Francisco",
+    "Tickets are selling fast, limited seats available register now!",
+  ];
+
+  return (
+    <>
+      {items.map((item) => (
+        <span
+          key={item}
+          style={{ whiteSpace: "nowrap" }}
+          className="inline-flex items-center gap-3 text-[12px] text-[#23120a] sm:text-[13px] lg:text-[14px]"
+        >
+          <span className="font-semibold">{item}</span>
+          <span className="inline-block h-[5px] w-[5px] shrink-0 rounded-full bg-[#23120a]/35" />
+        </span>
+      ))}
+    </>
+  );
+}
+
+const setBarHeight = (value) => {
+  if (typeof document !== "undefined") {
+    document.documentElement.style.setProperty(
+      "--docusaurus-announcement-bar-height",
+      value
+    );
+  }
+};
+
+export default function AnnouncementBar() {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isMarqueePaused, setIsMarqueePaused] = useState(false);
+  const [dragY, setDragY] = useState(0);
+  const [dismissing, setDismissing] = useState(false);
+  const containerRef = useRef(null);
+  const touchStartY = useRef(null);
+
+  useEffect(() => {
+    setIsVisible(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible || !containerRef.current) {
+      setBarHeight("0px");
+      return;
+    }
+
+    const node = containerRef.current;
+    const syncHeight = () =>
+      setBarHeight(`${node.offsetHeight}px`);
+
+    syncHeight();
+
+    const ro = new ResizeObserver(syncHeight);
+    ro.observe(node);
+    window.addEventListener("resize", syncHeight);
+
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", syncHeight);
+    };
+  }, [isVisible]);
+
+  const handleDismiss = () => setIsVisible(false);
+
+  const handleTouchStart = (e) => {
+    touchStartY.current = e.touches[0].clientY;
+  };
+
+  const handleTouchMove = (e) => {
+    if (touchStartY.current === null) return;
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (dy < 0) setDragY(dy);
+  };
+
+  const handleTouchEnd = () => {
+    if (dragY < -50) {
+      setDismissing(true);
+      setTimeout(handleDismiss, 220);
+    } else {
+      setDragY(0);
+    }
+    touchStartY.current = null;
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="banner"
+      aria-label="Event announcement"
+      className="sticky top-0 z-[100] border-b border-white/40 bg-cover bg-center bg-no-repeat shadow-[0_12px_30px_rgba(234,88,12,0.16)] backdrop-blur"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      style={{
+        backgroundImage:
+          "url('https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp')",
+        transform: dismissing ? "translateY(-110%)" : dragY < 0 ? `translateY(${dragY}px)` : undefined,
+        opacity: dismissing ? 0 : dragY < 0 ? Math.max(0.15, 1 + dragY / 60) : undefined,
+        transition: dragY !== 0 && !dismissing ? "none" : "transform 0.22s ease, opacity 0.18s ease",
+      }}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-white/10"
+      />
+
+      <div className="relative mx-auto max-w-[1440px] px-3 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
+        {/* Mobile: single row — marquee + compact CTA. Swipe up to dismiss. */}
+        <div className="flex min-w-0 items-center gap-2 lg:hidden">
+          <div
+            onMouseEnter={() => setIsMarqueePaused(true)}
+            onMouseLeave={() => setIsMarqueePaused(false)}
+            onPointerEnter={() => setIsMarqueePaused(true)}
+            onPointerLeave={() => setIsMarqueePaused(false)}
+            className="min-w-0 flex-1 overflow-hidden"
+          >
+            <MarqueeTrack paused={isMarqueePaused} repeat={10} duration="25s" gap="1.25rem">
+              <MarqueeContent />
+            </MarqueeTrack>
+          </div>
+
+          <Link
+            to={ANNOUNCEMENT.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group shrink-0 inline-flex h-6 items-center gap-1 rounded-full border border-black/90 bg-black px-2.5 text-[10px] font-semibold text-white transition hover:bg-[#0a0a0a] no-underline"
+            style={{ textDecoration: "none" }}
+          >
+            <span className="transition-all group-hover:bg-gradient-to-r group-hover:from-[#39ff14] group-hover:to-[#00f5ff] group-hover:bg-clip-text group-hover:text-transparent">
+              {ANNOUNCEMENT.ctaLabel}
+            </span>
+            <ArrowRight className="h-2.5 w-2.5 transition-colors group-hover:text-[#39ff14]" />
+          </Link>
+        </div>
+
+        {/* Desktop layout */}
+        <div className="hidden min-w-0 items-center gap-4 lg:flex">
+          <span className="inline-flex h-8 shrink-0 items-center justify-center gap-2 rounded-full border border-white/20 bg-black px-4 text-[10px] font-extrabold tracking-[0.08em] leading-none text-white">
+            <span className="relative flex h-2.5 w-2.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#00ff87]/75" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[#00ff87]" />
+            </span>
+            {ANNOUNCEMENT.eyebrow}
+          </span>
+
+          <div
+            className="min-w-0 flex-1 overflow-hidden"
+            onMouseEnter={() => setIsMarqueePaused(true)}
+            onMouseLeave={() => setIsMarqueePaused(false)}
+            onPointerEnter={() => setIsMarqueePaused(true)}
+            onPointerLeave={() => setIsMarqueePaused(false)}
+          >
+            <MarqueeTrack paused={isMarqueePaused} repeat={10} duration="35s" gap="1.5rem">
+              <MarqueeContent />
+            </MarqueeTrack>
+          </div>
+
+          <Link
+            to={ANNOUNCEMENT.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-4 text-[13px] font-semibold text-white shadow-[0_12px_28px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#0a0a0a] hover:shadow-[0_16px_34px_rgba(0,0,0,0.36)] no-underline"
+            style={{ textDecoration: "none" }}
+          >
+            <span className="transition-all group-hover:bg-gradient-to-r group-hover:from-[#39ff14] group-hover:to-[#00f5ff] group-hover:bg-clip-text group-hover:text-transparent">
+              {ANNOUNCEMENT.ctaLabel}
+            </span>
+            <ArrowRight className="h-3.5 w-3.5 transition-colors group-hover:text-[#39ff14]" />
+          </Link>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setIsVisible(false)}
+        aria-label="Dismiss announcement"
+        className="absolute right-3 top-1/2 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/[0.18] text-[#6f2b00] transition hover:bg-white/30 lg:right-4 lg:inline-flex"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -95,18 +95,6 @@ export default function AnnouncementBar() {
   const srAnnouncementText = [ANNOUNCEMENT.eyebrow, ...marqueeItems].join(". ");
 
   useEffect(() => {
-    if (
-      process.env.NODE_ENV !== "production" &&
-      announcementBar?.content &&
-      /<[^>]+>/.test(announcementBar.content)
-    ) {
-      console.warn(
-        "Custom AnnouncementBar treats themeConfig.announcementBar.content as plain text and strips HTML tags."
-      );
-    }
-  }, [announcementBar?.content]);
-
-  useEffect(() => {
     if (!isActive || !containerRef.current) {
       setBarHeight("0px");
       return;

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -91,7 +91,7 @@ export default function AnnouncementBar() {
   );
   const marqueeItems = buildAnnouncementItems(marqueeContent);
   const isCloseable = announcementBar?.isCloseable !== false;
-  const backgroundImageUrl = useBaseUrl("/img/GitTogether.jpg");
+  const backgroundImageUrl = useBaseUrl("https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp");
   const srAnnouncementText = [ANNOUNCEMENT.eyebrow, ...marqueeItems].join(". ");
 
   useEffect(() => {

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -14,6 +14,7 @@ const ANNOUNCEMENT = {
 function MarqueeTrack({paused, children, repeat = 10, duration, gap}) {
   return (
     <div
+      aria-hidden="true"
       className="group flex overflow-hidden [gap:var(--gap)]"
       style={{"--duration": duration, "--gap": gap}}
     >
@@ -87,6 +88,7 @@ export default function AnnouncementBar() {
   );
   const isCloseable = announcementBar?.isCloseable !== false;
   const backgroundImageUrl = useBaseUrl("/img/GitTogether.jpg");
+  const srAnnouncementText = `${ANNOUNCEMENT.eyebrow}. ${marqueeContent}. Keploy is hosting a community meetup in San Francisco! Tickets are selling fast. Limited seats available, register now!`;
 
   useEffect(() => {
     if (!isActive || !containerRef.current) {
@@ -98,10 +100,16 @@ export default function AnnouncementBar() {
     const syncHeight = () => setBarHeight(`${node.offsetHeight}px`);
 
     syncHeight();
+    window.addEventListener("resize", syncHeight);
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        window.removeEventListener("resize", syncHeight);
+      };
+    }
 
     const ro = new ResizeObserver(syncHeight);
     ro.observe(node);
-    window.addEventListener("resize", syncHeight);
 
     return () => {
       ro.disconnect();
@@ -247,6 +255,7 @@ export default function AnnouncementBar() {
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 bg-white/10"
       />
+      <span className="sr-only">{srAnnouncementText}</span>
 
       <div className="relative mx-auto max-w-[1440px] px-3 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
         {/* Mobile: single row with marquee, dismiss control, and compact CTA. */}

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -40,13 +40,15 @@ function stripHtml(value) {
     .trim();
 }
 
-function MarqueeContent({content}) {
-  const items = [
+function buildAnnouncementItems(content) {
+  return [
     content,
     "Keploy is hosting a community meetup in San Francisco!",
     "Tickets are selling fast. Limited seats available, register now!",
   ];
+}
 
+function MarqueeContent({items}) {
   return (
     <>
       {items.map((item, index) => (
@@ -83,12 +85,26 @@ export default function AnnouncementBar() {
   const dragFrameRef = useRef(null);
   const dismissTimeoutRef = useRef(null);
   const reduceMotionQueryRef = useRef(null);
+  // The marquee is intentionally text-only; links/actions are provided separately.
   const marqueeContent = stripHtml(
     announcementBar?.content || "GitTogether SF • May 14, 2026 • San Francisco"
   );
+  const marqueeItems = buildAnnouncementItems(marqueeContent);
   const isCloseable = announcementBar?.isCloseable !== false;
   const backgroundImageUrl = useBaseUrl("/img/GitTogether.jpg");
-  const srAnnouncementText = `${ANNOUNCEMENT.eyebrow}. ${marqueeContent}. Keploy is hosting a community meetup in San Francisco! Tickets are selling fast. Limited seats available, register now!`;
+  const srAnnouncementText = [ANNOUNCEMENT.eyebrow, ...marqueeItems].join(". ");
+
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== "production" &&
+      announcementBar?.content &&
+      /<[^>]+>/.test(announcementBar.content)
+    ) {
+      console.warn(
+        "Custom AnnouncementBar treats themeConfig.announcementBar.content as plain text and strips HTML tags."
+      );
+    }
+  }, [announcementBar?.content]);
 
   useEffect(() => {
     if (!isActive || !containerRef.current) {
@@ -104,6 +120,7 @@ export default function AnnouncementBar() {
 
     if (typeof ResizeObserver === "undefined") {
       return () => {
+        setBarHeight("0px");
         window.removeEventListener("resize", syncHeight);
       };
     }
@@ -112,6 +129,7 @@ export default function AnnouncementBar() {
     ro.observe(node);
 
     return () => {
+      setBarHeight("0px");
       ro.disconnect();
       window.removeEventListener("resize", syncHeight);
     };
@@ -276,7 +294,7 @@ export default function AnnouncementBar() {
               duration="25s"
               gap="1.25rem"
             >
-              <MarqueeContent content={marqueeContent} />
+              <MarqueeContent items={marqueeItems} />
             </MarqueeTrack>
           </Link>
 
@@ -331,7 +349,7 @@ export default function AnnouncementBar() {
               duration="35s"
               gap="1.5rem"
             >
-              <MarqueeContent content={marqueeContent} />
+              <MarqueeContent items={marqueeItems} />
             </MarqueeTrack>
           </Link>
 

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -1,6 +1,8 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, {useEffect, useRef, useState} from "react";
 import Link from "@docusaurus/Link";
-import { ArrowRight, X } from "lucide-react";
+import {useThemeConfig} from "@docusaurus/theme-common";
+import {useAnnouncementBar} from "@docusaurus/theme-common/internal";
+import {ArrowRight, X} from "lucide-react";
 
 const ANNOUNCEMENT = {
   eyebrow: "Event Live",
@@ -8,19 +10,19 @@ const ANNOUNCEMENT = {
   ctaLabel: "Register Now",
 };
 
-function MarqueeTrack({ paused, children, repeat = 10, duration, gap }) {
+function MarqueeTrack({paused, children, repeat = 10, duration, gap}) {
   return (
     <div
       className="group flex overflow-hidden [gap:var(--gap)]"
-      style={{ "--duration": duration, "--gap": gap }}
+      style={{"--duration": duration, "--gap": gap}}
     >
       {Array(repeat)
         .fill(0)
         .map((_, i) => (
           <div
             key={i}
-            className="flex shrink-0 flex-row justify-around [gap:var(--gap)] animate-marquee"
-            style={{ animationPlayState: paused ? "paused" : "running" }}
+            className="flex shrink-0 animate-marquee flex-row justify-around [gap:var(--gap)] motion-reduce:animate-none"
+            style={{animationPlayState: paused ? "paused" : "running"}}
           >
             {children}
           </div>
@@ -29,11 +31,18 @@ function MarqueeTrack({ paused, children, repeat = 10, duration, gap }) {
   );
 }
 
-function MarqueeContent() {
+function stripHtml(value) {
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function MarqueeContent({content}) {
   const items = [
+    content,
     "Keploy is hosting a community meetup in San Francisco!",
-    "GitTogether SF • May 14, 2026 • San Francisco",
-    "Tickets are selling fast, limited seats available register now!",
+    "Tickets are selling fast. Limited seats available, register now!",
   ];
 
   return (
@@ -41,7 +50,7 @@ function MarqueeContent() {
       {items.map((item) => (
         <span
           key={item}
-          style={{ whiteSpace: "nowrap" }}
+          style={{whiteSpace: "nowrap"}}
           className="inline-flex items-center gap-3 text-[12px] text-[#23120a] sm:text-[13px] lg:text-[14px]"
         >
           <span className="font-semibold">{item}</span>
@@ -62,26 +71,29 @@ const setBarHeight = (value) => {
 };
 
 export default function AnnouncementBar() {
-  const [isVisible, setIsVisible] = useState(false);
+  const {announcementBar} = useThemeConfig();
+  const {isActive, close} = useAnnouncementBar();
   const [isMarqueePaused, setIsMarqueePaused] = useState(false);
-  const [dragY, setDragY] = useState(0);
   const [dismissing, setDismissing] = useState(false);
   const containerRef = useRef(null);
   const touchStartY = useRef(null);
+  const dragYRef = useRef(0);
+  const dragFrameRef = useRef(null);
+  const dismissTimeoutRef = useRef(null);
+  const reduceMotionQueryRef = useRef(null);
+  const marqueeContent = stripHtml(
+    announcementBar?.content || "GitTogether SF • May 14, 2026 • San Francisco"
+  );
+  const isCloseable = announcementBar?.isCloseable !== false;
 
   useEffect(() => {
-    setIsVisible(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isVisible || !containerRef.current) {
+    if (!isActive || !containerRef.current) {
       setBarHeight("0px");
       return;
     }
 
     const node = containerRef.current;
-    const syncHeight = () =>
-      setBarHeight(`${node.offsetHeight}px`);
+    const syncHeight = () => setBarHeight(`${node.offsetHeight}px`);
 
     syncHeight();
 
@@ -93,31 +105,120 @@ export default function AnnouncementBar() {
       ro.disconnect();
       window.removeEventListener("resize", syncHeight);
     };
-  }, [isVisible]);
+  }, [isActive]);
 
-  const handleDismiss = () => setIsVisible(false);
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    reduceMotionQueryRef.current = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    );
+
+    return () => {
+      if (dismissTimeoutRef.current) {
+        window.clearTimeout(dismissTimeoutRef.current);
+      }
+      if (dragFrameRef.current) {
+        window.cancelAnimationFrame(dragFrameRef.current);
+      }
+    };
+  }, []);
+
+  const applyDragStyles = (offsetY, isExiting = false) => {
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+
+    if (isExiting) {
+      node.style.transform = "translateY(-110%)";
+      node.style.opacity = "0";
+      node.style.transition = "transform 0.22s ease, opacity 0.18s ease";
+      return;
+    }
+
+    if (offsetY < 0) {
+      node.style.transform = `translateY(${offsetY}px)`;
+      node.style.opacity = String(Math.max(0.15, 1 + offsetY / 60));
+      node.style.transition = "none";
+      return;
+    }
+
+    node.style.transform = "";
+    node.style.opacity = "";
+    node.style.transition = "";
+  };
+
+  const resetDrag = () => {
+    dragYRef.current = 0;
+    applyDragStyles(0);
+  };
+
+  const finalizeDismiss = () => {
+    dismissTimeoutRef.current = null;
+    resetDrag();
+    setDismissing(false);
+    close();
+  };
+
+  const beginDismiss = () => {
+    if (!isCloseable || dismissing) {
+      return;
+    }
+
+    if (dismissTimeoutRef.current) {
+      window.clearTimeout(dismissTimeoutRef.current);
+    }
+
+    setDismissing(true);
+    applyDragStyles(0, true);
+
+    if (reduceMotionQueryRef.current?.matches) {
+      finalizeDismiss();
+      return;
+    }
+
+    dismissTimeoutRef.current = window.setTimeout(finalizeDismiss, 220);
+  };
 
   const handleTouchStart = (e) => {
+    if (!isCloseable || dismissing) {
+      return;
+    }
     touchStartY.current = e.touches[0].clientY;
   };
 
   const handleTouchMove = (e) => {
     if (touchStartY.current === null) return;
     const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy < 0) setDragY(dy);
+    if (dy >= 0) {
+      return;
+    }
+
+    dragYRef.current = dy;
+
+    if (dragFrameRef.current) {
+      return;
+    }
+
+    dragFrameRef.current = window.requestAnimationFrame(() => {
+      dragFrameRef.current = null;
+      applyDragStyles(dragYRef.current);
+    });
   };
 
   const handleTouchEnd = () => {
-    if (dragY < -50) {
-      setDismissing(true);
-      setTimeout(handleDismiss, 220);
+    if (dragYRef.current < -50) {
+      beginDismiss();
     } else {
-      setDragY(0);
+      resetDrag();
     }
     touchStartY.current = null;
   };
 
-  if (!isVisible) {
+  if (!isActive) {
     return null;
   }
 
@@ -130,12 +231,15 @@ export default function AnnouncementBar() {
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
       style={{
         backgroundImage:
           "url('https://keploy-devrel.s3.us-west-2.amazonaws.com/landing/announcement-bar-bg.webp')",
-        transform: dismissing ? "translateY(-110%)" : dragY < 0 ? `translateY(${dragY}px)` : undefined,
-        opacity: dismissing ? 0 : dragY < 0 ? Math.max(0.15, 1 + dragY / 60) : undefined,
-        transition: dragY !== 0 && !dismissing ? "none" : "transform 0.22s ease, opacity 0.18s ease",
+        transform: dismissing ? "translateY(-110%)" : undefined,
+        opacity: dismissing ? 0 : undefined,
+        transition: dismissing
+          ? "transform 0.22s ease, opacity 0.18s ease"
+          : undefined,
       }}
     >
       <div
@@ -144,7 +248,7 @@ export default function AnnouncementBar() {
       />
 
       <div className="relative mx-auto max-w-[1440px] px-3 py-1 sm:px-5 sm:pr-12 lg:px-12 lg:py-1.5">
-        {/* Mobile: single row — marquee + compact CTA. Swipe up to dismiss. */}
+        {/* Mobile: single row with marquee, dismiss control, and compact CTA. */}
         <div className="flex min-w-0 items-center gap-2 lg:hidden">
           <div
             onMouseEnter={() => setIsMarqueePaused(true)}
@@ -153,17 +257,33 @@ export default function AnnouncementBar() {
             onPointerLeave={() => setIsMarqueePaused(false)}
             className="min-w-0 flex-1 overflow-hidden"
           >
-            <MarqueeTrack paused={isMarqueePaused} repeat={10} duration="25s" gap="1.25rem">
-              <MarqueeContent />
+            <MarqueeTrack
+              paused={isMarqueePaused}
+              repeat={10}
+              duration="25s"
+              gap="1.25rem"
+            >
+              <MarqueeContent content={marqueeContent} />
             </MarqueeTrack>
           </div>
+
+          {isCloseable && (
+            <button
+              type="button"
+              onClick={beginDismiss}
+              aria-label="Dismiss announcement"
+              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-[#6f2b00]/15 bg-white/65 text-[#6f2b00] transition hover:bg-white/85"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
 
           <Link
             to={ANNOUNCEMENT.href}
             target="_blank"
             rel="noopener noreferrer"
-            className="group shrink-0 inline-flex h-6 items-center gap-1 rounded-full border border-black/90 bg-black px-2.5 text-[10px] font-semibold text-white transition hover:bg-[#0a0a0a] no-underline"
-            style={{ textDecoration: "none" }}
+            className="group inline-flex h-6 shrink-0 items-center gap-1 rounded-full border border-black/90 bg-black px-2.5 text-[10px] font-semibold text-white no-underline transition hover:bg-[#0a0a0a]"
+            style={{textDecoration: "none"}}
           >
             <span className="transition-all group-hover:bg-gradient-to-r group-hover:from-[#39ff14] group-hover:to-[#00f5ff] group-hover:bg-clip-text group-hover:text-transparent">
               {ANNOUNCEMENT.ctaLabel}
@@ -174,7 +294,7 @@ export default function AnnouncementBar() {
 
         {/* Desktop layout */}
         <div className="hidden min-w-0 items-center gap-4 lg:flex">
-          <span className="inline-flex h-8 shrink-0 items-center justify-center gap-2 rounded-full border border-white/20 bg-black px-4 text-[10px] font-extrabold tracking-[0.08em] leading-none text-white">
+          <span className="inline-flex h-8 shrink-0 items-center justify-center gap-2 rounded-full border border-white/20 bg-black px-4 text-[10px] font-extrabold leading-none tracking-[0.08em] text-white">
             <span className="relative flex h-2.5 w-2.5">
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#00ff87]/75" />
               <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[#00ff87]" />
@@ -189,8 +309,13 @@ export default function AnnouncementBar() {
             onPointerEnter={() => setIsMarqueePaused(true)}
             onPointerLeave={() => setIsMarqueePaused(false)}
           >
-            <MarqueeTrack paused={isMarqueePaused} repeat={10} duration="35s" gap="1.5rem">
-              <MarqueeContent />
+            <MarqueeTrack
+              paused={isMarqueePaused}
+              repeat={10}
+              duration="35s"
+              gap="1.5rem"
+            >
+              <MarqueeContent content={marqueeContent} />
             </MarqueeTrack>
           </div>
 
@@ -198,8 +323,8 @@ export default function AnnouncementBar() {
             to={ANNOUNCEMENT.href}
             target="_blank"
             rel="noopener noreferrer"
-            className="group inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-4 text-[13px] font-semibold text-white shadow-[0_12px_28px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#0a0a0a] hover:shadow-[0_16px_34px_rgba(0,0,0,0.36)] no-underline"
-            style={{ textDecoration: "none" }}
+            className="group inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/90 bg-black px-4 text-[13px] font-semibold text-white no-underline shadow-[0_12px_28px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#0a0a0a] hover:shadow-[0_16px_34px_rgba(0,0,0,0.36)]"
+            style={{textDecoration: "none"}}
           >
             <span className="transition-all group-hover:bg-gradient-to-r group-hover:from-[#39ff14] group-hover:to-[#00f5ff] group-hover:bg-clip-text group-hover:text-transparent">
               {ANNOUNCEMENT.ctaLabel}
@@ -209,14 +334,16 @@ export default function AnnouncementBar() {
         </div>
       </div>
 
-      <button
-        type="button"
-        onClick={() => setIsVisible(false)}
-        aria-label="Dismiss announcement"
-        className="absolute right-3 top-1/2 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/[0.18] text-[#6f2b00] transition hover:bg-white/30 lg:right-4 lg:inline-flex"
-      >
-        <X className="h-4 w-4" />
-      </button>
+      {isCloseable && (
+        <button
+          type="button"
+          onClick={beginDismiss}
+          aria-label="Dismiss announcement"
+          className="absolute right-3 top-1/2 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-white/75 bg-white/[0.18] text-[#6f2b00] transition hover:bg-white/30 lg:right-4 lg:inline-flex"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/theme/Heading/styles.module.css
+++ b/src/theme/Heading/styles.module.css
@@ -4,7 +4,9 @@ the browser does not scroll that anchor behind the navbar
 See https://twitter.com/JoshWComeau/status/1332015868725891076
  */
 .anchorWithStickyNavbar {
-  scroll-margin-top: calc(var(--ifm-navbar-height) + 0.2rem);
+  scroll-margin-top: calc(
+    var(--keploy-header-offset, var(--ifm-navbar-height)) + 0.2rem
+  );
 }
 
 .anchorWithHideOnScrollNavbar {
@@ -20,7 +22,7 @@ See https://twitter.com/JoshWComeau/status/1332015868725891076
 
 /* Removed the '#' after headings */
 :global(.hash-link::before) {
-  content: '';
+  content: "";
 }
 
 :global(.hash-link:focus),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -126,9 +126,14 @@ module.exports = {
             transform: "translateY(0)",
           },
         },
+        marquee: {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(calc(-100% - var(--gap)))" },
+        },
       },
       animation: {
         "fade-in-down": "fade-in-down 0.5s ease-out",
+        marquee: "marquee var(--duration) linear infinite",
       },
       colors: {
         offwhite: "#F2F2F2",


### PR DESCRIPTION
Added a custom sticky announcement experience for GitTogether SF using the swizzled Docusaurus announcement bar.

### What changed

- Added a sticky announcement bar above the navbar for event promotion.
- Kept the desktop and mobile layouts responsive, including CTA and dismiss controls.
- Added marquee highlights with hover-to-pause behavior and click-through navigation to the event page.
- Wired the bar into Docusaurus announcement bar state so dismissal respects the configured announcement id and persists across navigation/reload.
- Updated header offsets so sticky navbar, breadcrumbs, and anchor scroll positions account for the announcement height consistently.
- Switched the visual treatment to use a repo-shipped image asset instead of an external runtime dependency.

### Configuration

- Announcement copy, id, and closeability are configured through `themeConfig.announcementBar` in `docusaurus.config.js`.
- The bar can be disabled by removing `themeConfig.announcementBar` from the config.
