### PR TITLE
fix: restore Vale workflow and dynamic dedup TOC

### DIFF
--- a/.github/workflows/vale-lint-action.yml
+++ b/.github/workflows/vale-lint-action.yml
@@ -8,19 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-
-      - name: Collect changed docs
-        id: changed-docs
-        shell: bash
-        run: |
-          files=$(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" -- 'versioned_docs/**/*.md' | paste -sd, -)
-          echo "files=${files}" >> "$GITHUB_OUTPUT"
 
       # Set up Vale Action — only lint changed lines to avoid flagging pre-existing issues.
       - uses: errata-ai/vale-action@v2.1.1
-        if: steps.changed-docs.outputs.files != ''
         with:
           # Only check lines added/modified in the PR diff.
           filter_mode: diff_context
@@ -28,11 +18,8 @@ jobs:
           reporter: github-pr-check
           # Fails the action if there are errors
           fail_on_error: true
-          # Lint only changed versioned docs. The action fails on all Vale output
-          # before reviewdog filters annotations, so a broad directory here makes
-          # pre-existing docs issues fail unrelated PRs.
-          files: ${{ steps.changed-docs.outputs.files }}
-          separator: ','
+          # Lint docs across all versioned directories
+          files: 'versioned_docs'
           # Specify the Vale version
           version: 3.0.3
         env:

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -38,7 +38,7 @@ keploy test -c "docker compose up" --containerName containerName --dedup
 
 ### For Golang Applications
 
-**1. Pre-requisite**
+#### 1. Pre-requisite
 
 Install the `keploy/go-sdk/v3/keploy` : -
 
@@ -52,7 +52,7 @@ Add the following on top of your main application file : -
 import _ "github.com/keploy/go-sdk/v3/keploy"
 ```
 
-**2. Build Configuration**
+#### 2. Build Configuration
 
 Update the `go build` command in your Dockerfile (or native build script) to include coverage flags. These are required for deduplication to calculate coverage accurately.
 
@@ -60,7 +60,7 @@ Update the `go build` command in your Dockerfile (or native build script) to inc
 RUN go build -cover -covermode=atomic -coverpkg=./... -o /app/main .
 ```
 
-**3. Dockerfile Configuration (Important for Docker Users)**
+#### 3. Dockerfile Configuration (Important for Docker Users)
 
 If you are using a multi-stage Docker build (e.g., building in one stage and running in a slim image), you **must** ensure the Go toolchain and `go.mod` files are preserved in the final runtime image. The deduplication feature requires access to the Go runtime to map coverage data correctly.
 
@@ -87,7 +87,7 @@ ENV GOMOD=/app/go.mod
 
 > **Note:** If you face issues with toolchain downloads in restricted environments, you may also need to set `ENV GOTOOLCHAIN=local` and configure your `GOPROXY` in the Dockerfile.
 
-**4. Run Deduplication**
+#### 4. Run Deduplication
 
 For Docker, run:
 


### PR DESCRIPTION
## Summary
- restore the Vale workflow to the original versioned_docs scope
- restore the dynamic dedup page step headings so Go and Java steps appear in the side table of contents

## Verification
- npx prettier --check versioned_docs/version-4.0.0/keploy-cloud/deduplication.md .github/workflows/vale-lint-action.yml
- git diff --check