### PR TITLE
docs(static-dedup): document custom-dedup-fields → schema enums; note k8s-proxy auth WIP

### DIFF
--- a/versioned_docs/version-4.0.0/keploy-cloud/static-deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/static-deduplication.md
@@ -2,7 +2,7 @@
 id: static-deduplication
 title: Static Deduplication
 sidebar_label: Static Deduplication
-description: Drop schema-identical live traffic at record time so only distinct request shapes become test cases. Configure per-endpoint value-aware dedup with custom fields.
+description: Drop schema-identical live traffic at record time so only distinct request shapes become test cases. Mark fields with custom-dedup-fields to keep value-distinct traffic and surface observed values as enums in the generated OpenAPI schema.
 tags:
   - deduplication
   - recording
@@ -17,6 +17,8 @@ keywords:
   - recording dedup
   - keploy enterprise
   - dedup stats
+  - openapi enum
+  - schema enum generation
 ---
 
 import ProductTier from '@site/src/components/ProductTier';
@@ -92,6 +94,84 @@ curl -s -X POST "$PROXY/record/start" \
     "record_config": { "static_dedup": true }
   }'
 ```
+
+## Custom dedup fields → OpenAPI enum values
+
+Marking specific request or response fields with `custom-dedup-fields` does two things during a recording:
+
+1. **Sharper signatures.** Values from those fields are appended to the dedup hash, so two requests with the same shape but different marked-field values stay as distinct test cases instead of collapsing into one.
+2. **Enum-aware schema generation.** When auto-replay generates the OpenAPI document for the recorded service, the distinct scalar values observed for each marked field are emitted as an `enum` array on the matching response (or request) property — turning the dedup hints into machine-readable contract documentation.
+
+### Configure marked fields
+
+Add a `custom-dedup-fields` block under `agent:` in `keploy.yml`:
+
+```yaml
+agent:
+  static-dedup: true
+  custom-dedup-fields:
+    - method: GET
+      path: /products/{id}
+      statusCode: 200
+      fields:
+        - response.product_id
+    - method: GET
+      path: /api/v1/data
+      statusCode: 200
+      fields:
+        - response.version
+```
+
+For Kubernetes Proxy recordings, send the same list inside `record_config.custom_dedup_fields` on `POST /record/start`. Updating the config applies to newly started or restarted agent processes.
+
+Field-path rules:
+
+- `request.X` — resolve `X` (dot-notated) in the request body.
+- `response.X` — resolve it in the response body.
+- Bare `X` — try the request body first, fall back to the response body.
+- Path matching uses the same `{id}` normalisation as the base signature, so `/products/42` in traffic matches `/products/{id}` in config. Method matching is case-insensitive.
+
+You can also pass the same JSON via the CLI:
+
+```bash
+keploy enterprise record --static-dedup \
+  --custom-dedup-fields='[{"method":"GET","path":"/products/{id}","statusCode":200,"fields":["response.product_id"]}]' \
+  -c "docker compose up"
+```
+
+### What ends up in the schema
+
+Suppose the recorded session captures these `GET /products/{id}` responses across the run:
+
+```text
+GET /products/1   → { "name": "...", "price": ..., "product_id": "1"   }
+GET /products/42  → { "name": "...", "price": ..., "product_id": "42"  }
+GET /products/999 → { "name": "...", "price": ..., "product_id": "999" }
+```
+
+After auto-replay, the OpenAPI document Keploy generates for the service includes an `enum` listing every distinct value observed for the marked field:
+
+```json
+"GetProducts200Response": {
+  "properties": {
+    "name":  { "type": "string" },
+    "price": { "type": "number" },
+    "product_id": {
+      "enum": ["1", "42", "999"],
+      "type": "string"
+    }
+  },
+  "type": "object"
+}
+```
+
+Without the `custom-dedup-fields` entry the property would be `"product_id": { "type": "string" }` — the inferred type is still correct, but the discrete value space is lost. The same generated document is what the **Schemas** section of the Keploy console renders, so the enum values are visible directly in the UI.
+
+### Caveats
+
+- **Scalar leaves only.** Object and array values are skipped — point field paths at primitives (string, number, boolean, null).
+- **Saturation cap.** If a marked field crosses **50 distinct values** during a single schema generation, Keploy drops the `enum` for that field entirely rather than emit a misleadingly truncated list. The property's `type` is still inferred normally.
+- **Object response shape.** If an endpoint returns a top-level JSON array (e.g. `[{"id":...}, ...]`), a path like `response.id` does not resolve into the array elements and no enum is emitted for that endpoint.
 
 ## When should I use this?
 

--- a/versioned_docs/version-4.0.0/keploy-cloud/static-deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/static-deduplication.md
@@ -100,7 +100,7 @@ curl -s -X POST "$PROXY/record/start" \
 Marking specific request or response fields with `custom-dedup-fields` does two things during a recording:
 
 1. **Sharper signatures.** Values from those fields are appended to the dedup hash, so two requests with the same shape but different marked-field values stay as distinct test cases instead of collapsing into one.
-2. **Enum-aware schema generation.** When auto-replay generates the OpenAPI document for the recorded service, the distinct scalar values observed for each marked field are emitted as an `enum` array on the matching response (or request) property — turning the dedup hints into machine-readable contract documentation.
+2. **Enum-aware schema generation.** When auto-replay generates the OpenAPI document for the recorded service, the distinct scalar values observed for each marked field are emitted as an `enum` array on the matching response (or request) property—turning the dedup hints into machine-readable contract documentation.
 
 ### Configure marked fields
 
@@ -126,9 +126,9 @@ For Kubernetes Proxy recordings, send the same list inside `record_config.custom
 
 Field-path rules:
 
-- `request.X` — resolve `X` (dot-notated) in the request body.
-- `response.X` — resolve it in the response body.
-- Bare `X` — try the request body first, fall back to the response body.
+- `request.X`—resolve `X` (dot-notated) in the request body.
+- `response.X`—resolve it in the response body.
+- Bare `X`—try the request body first, fall back to the response body.
 - Path matching uses the same `{id}` normalisation as the base signature, so `/products/42` in traffic matches `/products/{id}` in config. Method matching is case-insensitive.
 
 You can also pass the same JSON via the CLI:
@@ -165,11 +165,11 @@ After auto-replay, the OpenAPI document Keploy generates for the service include
 }
 ```
 
-Without the `custom-dedup-fields` entry the property would be `"product_id": { "type": "string" }` — the inferred type is still correct, but the discrete value space is lost. The same generated document is what the **Schemas** section of the Keploy console renders, so the enum values are visible directly in the UI.
+Without the `custom-dedup-fields` entry the property would be `"product_id": { "type": "string" }`—the inferred type is still correct, but the discrete value space is lost. The same generated document is what the **Schemas** section of the Keploy console renders, so the enum values are visible directly in the UI.
 
 ### Caveats
 
-- **Scalar leaves only.** Object and array values are skipped — point field paths at primitives (string, number, boolean, null).
+- **Scalar leaves only.** Object and array values are skipped—point field paths at primitives (`string`, `number`, `bool`, `null`).
 - **Saturation cap.** If a marked field crosses **50 distinct values** during a single schema generation, Keploy drops the `enum` for that field entirely rather than emit a misleadingly truncated list. The property's `type` is still inferred normally.
 - **Object response shape.** If an endpoint returns a top-level JSON array (e.g. `[{"id":...}, ...]`), a path like `response.id` does not resolve into the array elements and no enum is emitted for that endpoint.
 

--- a/versioned_docs/version-4.0.0/keploy-cloud/static-deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/static-deduplication.md
@@ -72,17 +72,9 @@ record:
 
 agent:
   static-dedup: true
-  # Optional: sharpen dedup on specific endpoints—see below.
-  custom-dedup-fields:
-    - method: POST
-      path: /orders
-      statusCode: 201
-      fields:
-        - response.status
-        - request.currency
 ```
 
-`record.static-dedup` enables the feature for `keploy record`; `agent.static-dedup` (and `agent.custom-dedup-fields`) are forwarded to the agent process so it applies the filter in real time.
+`record.static-dedup` enables the feature for `keploy record`; `agent.static-dedup` is forwarded to the agent process so it applies the filter in real time.
 
 ### Kubernetes Proxy
 
@@ -100,80 +92,6 @@ curl -s -X POST "$PROXY/record/start" \
     "record_config": { "static_dedup": true }
   }'
 ```
-
-The same session will stream a `static_dedup_stats` array in its `/record/status` updates so you can watch dedup effectiveness live from the Keploy Console.
-
-## Custom dedup fields (value-aware dedup)
-
-The default signature is **shape-based**: two POST `/orders` requests with the same JSON field types collapse, even if their values differ. That is usually what you want—but sometimes distinct _values_ represent distinct behaviour you want to capture (e.g. `response.status: "SUCCESS"` vs `"REFUNDED"`).
-
-Configure `custom-dedup-fields` to append a value-based fingerprint to the signature for matching endpoints:
-
-```yaml
-agent:
-  static-dedup: true
-  custom-dedup-fields:
-    - method: POST
-      path: /orders/{id}/refund
-      statusCode: 200
-      fields:
-        - response.status # look in response body
-        - request.currency # look in request body
-        - customerTier # try request body, then response body
-```
-
-**Field-path rules:**
-
-- `request.X`—resolve `X` (dot-notated) in the request body.
-- `response.X`—resolve it in the response body.
-- Bare `X`—try the request body first, fall back to the response body.
-- Missing or non-JSON fields contribute a `__MISSING__` sentinel, so _present-but-empty_ stays distinct from _absent_.
-
-Paths are matched case-insensitively on method, and the URL path uses the same normalisation as the base signature—so `/orders/42/refund` in traffic matches `/orders/{id}/refund` in config.
-
-You can also pass this from the CLI as JSON:
-
-```bash
-keploy enterprise record --static-dedup \
-  --custom-dedup-fields='[{"method":"POST","path":"/orders/{id}/refund","statusCode":200,"fields":["response.status","request.currency"]}]' \
-  -c "docker compose up"
-```
-
-For Kubernetes Proxy recordings, custom fields are sent in `record_config.custom_dedup_fields` and passed to the injected agent with the recording session. Updating the config applies to newly started or restarted agent processes.
-
-## Observe dedup effectiveness
-
-The agent exposes a live stats endpoint when static dedup is enabled:
-
-```bash
-curl -s http://<agent-host>:<port>/dedup/stats | jq
-```
-
-```json
-[
-  {
-    "method": "POST",
-    "url": "/orders",
-    "status_code": 201,
-    "total_count": 14832,
-    "duplicate_count": 14816,
-    "schema_key": "POST|/orders|content-type_authorization|201|content-type|17834...|93482..."
-  },
-  {
-    "method": "GET",
-    "url": "/orders/{id}",
-    "status_code": 200,
-    "total_count": 4201,
-    "duplicate_count": 4198,
-    "schema_key": "GET|/orders/{id}|authorization|200|content-type|0|81921..."
-  }
-]
-```
-
-- `total_count`—how many times this signature was seen.
-- `duplicate_count`—how many of those were dropped (always `total_count - 1` when the first was recorded).
-
-When static dedup is disabled, `/dedup/stats` is not available for that agent. Depending on how the agent was started, callers may see a `404` route-not-found response or `static dedup disabled`. Through the Kubernetes Proxy, the same data is embedded in each `/record/status` event as `static_dedup_stats`, so you rarely need to call `/dedup/stats` directly.
 
 ## When should I use this?
 

--- a/versioned_docs/version-4.0.0/running-keploy/k8s-proxy-api.md
+++ b/versioned_docs/version-4.0.0/running-keploy/k8s-proxy-api.md
@@ -64,6 +64,10 @@ Running the Keploy enterprise CLI inside a Pod works, but it is a per-app, per-n
 
 ## Authentication
 
+:::info In development
+The authentication flow is currently in development.
+:::
+
 Every protected proxy endpoint requires the cluster **shared token**. Send it as a Bearer token:
 
 ```text


### PR DESCRIPTION
## What has changed?

Three related updates to the Keploy Cloud / Enterprise docs:

1. **Static Deduplication — `custom-dedup-fields` → OpenAPI enum values (new section).** Documents the dual role the `custom-dedup-fields` config now plays:
   - Sharpens the dedup signature (existing behaviour) so two requests with the same shape but different values for marked fields stay as distinct test cases.
   - **New:** during auto-replay schema generation, the distinct scalar values observed for each marked field are emitted as an `enum` array on the matching response (or request) property, so the values surface in the generated OpenAPI document and in the console's **Schemas** section. Includes the config example, a before/after schema snippet for `GetProducts200Response`, and the caveats: scalar leaves only, **50-distinct-value saturation cap** (drop-rather-than-truncate), and object-response shape (top-level JSON arrays don't match `response.X` paths).

2. **Static Deduplication trim (already in this branch).** Removes the prior, out-of-date `Custom dedup fields` and `Observe dedup effectiveness` (`/dedup/stats`) sections so the page reflects what's actually shipped today. The new section above replaces the removed `custom-dedup-fields` material with up-to-date content tied to the schema-enum behaviour.

3. **Kubernetes Proxy API — Authentication WIP notice (already in this branch).** Adds an `:::info In development` admonition above the Authentication section of `running-keploy/k8s-proxy-api.md` so readers don't try to wire the shared-token flow into automation while it's still moving.

## Type of change

- [x] New feature (non-breaking change which adds functionality) — documents the new schema-enum emission path for `custom-dedup-fields`.
- [x] Documentation update.

## How Has This Been Tested?

- Verified end-to-end against a self-hosted k8s-proxy + agent recording of a small Go service with three configured dedup fields (`response.id`, `response.version`, `response.product_id`).
- Stop-recording → auto-replay → schema generation produced an OpenAPI document with `enum` arrays on the marked properties exactly as documented in the new section. Sample observed values: `"product_id": { "enum": ["1","5","7","42","100","999","2024"], "type": "string" }`.
- Fetched the same schema through the api-server-compatible `/k8s-proxy/get/schema` endpoint and confirmed the `enum` arrays survive the read path that backs the console's Schemas page.
- Local `npm run build` / `npm run serve` checks still recommended before merge.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.