### PR TITLE
docs: document Java dedup agent setup

### DIFF
--- a/vale_styles/config/vocabularies/Base/accept.txt
+++ b/vale_styles/config/vocabularies/Base/accept.txt
@@ -48,6 +48,7 @@ json_contains
 json_equal
 json_path
 JUnit
+[Kk]araf
 kubectl
 kubernetes
 test-gen

--- a/vale_styles/config/vocabularies/Base/accept.txt
+++ b/vale_styles/config/vocabularies/Base/accept.txt
@@ -20,10 +20,12 @@ Deduplication
 distros
 dockerfile
 Docusaurus
+Dropwizard
 expected_string
 Functionize
 GitHub
 gjson
+Gradle
 graphql
 Hacktoberfest
 HAProxy
@@ -40,6 +42,7 @@ Idempotency
 JaCoCo
 Jacoco
 JBehave
+Jersey
 JMeter
 json_contains
 json_equal
@@ -68,6 +71,7 @@ Redis
 [Rr]epo
 Reqnroll
 SDK
+servlet
 signin
 Spotify
 status_code

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -121,7 +121,9 @@ keploy dedup --rm
 
 #### 1. Pre-requisite
 
-Copy the Keploy Java agent jar during your build. Do not add it as an application dependency, and do not import Keploy classes from application code.
+Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic — Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
+
+Copy both jars into `target/` during your Maven build (do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code). Tested with JaCoCo `0.8.12`.
 
 ```xml
 <plugin>
@@ -132,9 +134,7 @@ Copy the Keploy Java agent jar during your build. Do not add it as an applicatio
     <execution>
       <id>copy-keploy-java-agent</id>
       <phase>package</phase>
-      <goals>
-        <goal>copy</goal>
-      </goals>
+      <goals><goal>copy</goal></goals>
       <configuration>
         <artifactItems>
           <artifactItem>
@@ -147,31 +147,36 @@ Copy the Keploy Java agent jar during your build. Do not add it as an applicatio
         </artifactItems>
       </configuration>
     </execution>
+    <execution>
+      <id>copy-jacoco-agent</id>
+      <phase>package</phase>
+      <goals><goal>copy</goal></goals>
+      <configuration>
+        <artifactItems>
+          <artifactItem>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>0.8.12</version>
+            <classifier>runtime</classifier>
+            <type>jar</type>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <destFileName>jacocoagent.jar</destFileName>
+          </artifactItem>
+        </artifactItems>
+      </configuration>
+    </execution>
   </executions>
 </plugin>
 ```
 
-Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to start the dedup control socket, and attach the JaCoCo Java agent to provide coverage data. In the common path there are no TCP server flags and no `--pass-through-ports`.
-
-The Java agent is framework-agnostic. It can be attached to Spring Boot apps, Dropwizard/Jersey apps, plain executable jars, classpath-based apps, servlet/WAR-style archives, and other JVM frameworks as long as the application JVM also runs the JaCoCo agent.
+Run the app with both agents attached:
 
 ```bash
 java \
   -javaagent:target/keploy-sdk.jar \
-  -javaagent:/path/to/org.jacoco.agent-runtime.jar \
+  -javaagent:target/jacocoagent.jar \
   -jar target/app.jar
 ```
-
-If the in-process API is unavailable for some reason (for example, an isolated class loader), the SDK transparently falls back to JaCoCo's TCP server mode. To force the fallback, launch JaCoCo in `tcpserver` mode and tell Keploy to leave that port alone:
-
-```bash
-java \
-  -javaagent:target/keploy-sdk.jar \
-  -javaagent:/path/to/org.jacoco.agent-runtime.jar=address=127.0.0.1,port=36320,output=tcpserver \
-  -jar target/app.jar
-```
-
-The default JaCoCo endpoint for the fallback is `127.0.0.1:36320`. You can override it with `KEPLOY_JACOCO_HOST` and `KEPLOY_JACOCO_PORT`, or with the JVM properties `keploy.jacoco.host` and `keploy.jacoco.port`. When using the fallback, add the JaCoCo port to `--pass-through-ports` so coverage-control traffic is not mocked.
 
 #### 2. Build Configuration
 
@@ -185,31 +190,21 @@ By default, the SDK scans Maven `target/classes`, Gradle `build/classes/java/mai
 
 #### 3. Dockerfile Configuration (Important for Docker Users)
 
-When you use Docker or Docker Compose, make sure the final runtime image contains:
-
-- the runnable application jar,
-- the Keploy Java agent jar,
-- the JaCoCo runtime agent jar,
-- the compiled classes or the fat jar that contains the application classes.
-
-For example:
+When you use Docker or Docker Compose, copy four artifacts into the runtime image and attach both agents in the entrypoint:
 
 ```dockerfile
-COPY target/app.jar /app/app.jar
-COPY target/keploy-sdk.jar /app/keploy-sdk.jar
-COPY target/classes /app/target/classes
-COPY jacocoagent.jar /app/jacocoagent.jar
+COPY target/app.jar           /app/app.jar
+COPY target/keploy-sdk.jar    /app/keploy-sdk.jar
+COPY target/jacocoagent.jar   /app/jacocoagent.jar
+COPY target/classes           /app/target/classes
+
+ENTRYPOINT ["java", \
+  "-javaagent:/app/keploy-sdk.jar", \
+  "-javaagent:/app/jacocoagent.jar", \
+  "-jar", "/app/app.jar"]
 ```
 
-Then run the app with the JaCoCo agent attached:
-
-```bash
-java -javaagent:/app/keploy-sdk.jar -javaagent:/app/jacocoagent.jar -jar /app/app.jar
-```
-
-Keploy and the Java SDK exchange per-test coverage signals over `/tmp/coverage_control.sock` and `/tmp/coverage_data.sock`. For Docker and Docker Compose, Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container so both processes see the same socket paths.
-
-For hardened Docker runs, the Java dedup sample is validated with a non-root runtime user, a read-only root filesystem, dropped Linux capabilities, `no-new-privileges`, and Keploy's shared `/tmp` named volume for the Keploy control/data sockets and JaCoCo output. Do not add a conflicting `/tmp` bind mount or `tmpfs`; Keploy requires the injected shared `/tmp` volume to reach the Java SDK control socket.
+Keploy injects a shared `keploy-sockets-vol:/tmp` mount into both the application container and the Keploy agent container at replay time so the dedup sockets are visible on both sides. Keep `/tmp` writable in the container; do not add a conflicting `/tmp` bind mount or `tmpfs`. Restricted containers (non-root user, read-only root filesystem, dropped capabilities) work as long as `/tmp` stays writable.
 
 #### 4. Run Deduplication
 
@@ -222,22 +217,16 @@ keploy test -c "docker compose up" --container-name containerName --dedup --lang
 For Native, run:
 
 ```bash
-keploy test -c "java -javaagent:target/keploy-sdk.jar -javaagent:/path/to/org.jacoco.agent-runtime.jar -jar target/app.jar" --dedup --language java
+keploy test -c "java -javaagent:target/keploy-sdk.jar -javaagent:target/jacocoagent.jar -jar target/app.jar" --dedup --language java
 ```
 
-If the SDK falls back to the JaCoCo TCP server, also pass `--pass-through-ports <jacoco-port>` so Keploy does not try to mock the coverage-control connection.
-
-This will generate a `dedupData.yaml` file.
-
-After this, run:
+This produces `dedupData.yaml` — a per-testcase coverage map (`testSetID/testCaseID` → executed lines per source file) Keploy uses to compute redundancy.
 
 ```bash
 keploy dedup
 ```
 
-This command will create a `duplicates.yaml` file containing the test cases that dynamic deduplication marked as redundant.
-
-To apply the dynamic deduplication cleanup to the local Keploy test set, run:
+This reads `dedupData.yaml` and writes `duplicates.yaml`, listing the testcases that dedup marked redundant (grouped by test-set). To remove those testcases from the local Keploy test set:
 
 ```bash
 keploy dedup --rm

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -140,7 +140,7 @@ Copy the Keploy Java agent jar during your build. Do not add it as an applicatio
           <artifactItem>
             <groupId>io.keploy</groupId>
             <artifactId>keploy-sdk</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.6</version>
             <outputDirectory>${project.build.directory}</outputDirectory>
             <destFileName>keploy-sdk.jar</destFileName>
           </artifactItem>

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -140,7 +140,7 @@ Copy the Keploy Java agent jar during your build. Do not add it as an applicatio
           <artifactItem>
             <groupId>io.keploy</groupId>
             <artifactId>keploy-sdk</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
             <outputDirectory>${project.build.directory}</outputDirectory>
             <destFileName>keploy-sdk.jar</destFileName>
           </artifactItem>

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -140,7 +140,7 @@ Copy the Keploy Java agent jar during your build. Do not add it as an applicatio
           <artifactItem>
             <groupId>io.keploy</groupId>
             <artifactId>keploy-sdk</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.0</version>
             <outputDirectory>${project.build.directory}</outputDirectory>
             <destFileName>keploy-sdk.jar</destFileName>
           </artifactItem>

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -186,7 +186,7 @@ Build the application before running Keploy so the Java class files are availabl
 mvn clean package -DskipTests
 ```
 
-By default, the SDK scans Maven `target/classes`, Gradle `build/classes/java/main`, executable jars, Spring Boot `BOOT-INF/classes`, servlet `WEB-INF/classes`, and runtime classpath archives. For custom layouts or restricted Docker images, set `KEPLOY_JAVA_CLASS_DIRS` to the class directories or archives that should be analyzed.
+By default, the SDK scans Maven `target/classes`, Gradle `build/classes/java/main`, executable jars, Spring Boot `BOOT-INF/classes`, servlet `WEB-INF/classes`, and runtime classpath archives. For custom layouts or restricted Docker images, set `KEPLOY_JAVA_CLASS_DIRS` to the class directories or archives that should be analyzed. For shaded or uber-jar Docker images, copy the compiled application classes into the image and point `KEPLOY_JAVA_CLASS_DIRS` at that directory so dependency classes do not participate in dedup signatures.
 
 #### 3. Dockerfile Configuration (Important for Docker Users)
 
@@ -196,7 +196,9 @@ When you use Docker or Docker Compose, copy four artifacts into the runtime imag
 COPY target/app.jar           /app/app.jar
 COPY target/keploy-sdk.jar    /app/keploy-sdk.jar
 COPY target/jacocoagent.jar   /app/jacocoagent.jar
-COPY target/classes           /app/target/classes
+COPY target/classes           /app/classes
+
+ENV KEPLOY_JAVA_CLASS_DIRS=/app/classes
 
 ENTRYPOINT ["java", \
   "-javaagent:/app/keploy-sdk.jar", \

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -121,47 +121,53 @@ keploy dedup --rm
 
 #### 1. Pre-requisite
 
-Add the Keploy Java SDK to your application:
+Copy the Keploy Java agent jar during your build. Do not add it as an application dependency, and do not import Keploy classes from application code.
 
 ```xml
-<dependency>
-    <groupId>io.keploy</groupId>
-    <artifactId>keploy-sdk</artifactId>
-    <version>2.0.0</version>
-</dependency>
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-dependency-plugin</artifactId>
+  <version>3.6.1</version>
+  <executions>
+    <execution>
+      <id>copy-keploy-java-agent</id>
+      <phase>package</phase>
+      <goals>
+        <goal>copy</goal>
+      </goals>
+      <configuration>
+        <artifactItems>
+          <artifactItem>
+            <groupId>io.keploy</groupId>
+            <artifactId>keploy-sdk</artifactId>
+            <version>2.0.1</version>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <destFileName>keploy-sdk.jar</destFileName>
+          </artifactItem>
+        </artifactItems>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
 ```
 
-For Spring Boot 2 or other `javax.servlet` applications, register the Keploy middleware in your main class:
+Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to start the dedup control socket, and attach the JaCoCo Java agent to provide coverage data. In the common path there are no TCP server flags and no `--pass-through-ports`.
 
-```java
-import io.keploy.servlet.KeployMiddleware;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
-
-@SpringBootApplication
-@Import(KeployMiddleware.class)
-public class App {
-}
-```
-
-For Spring Boot 3, Jakarta EE applications, other frameworks, or custom launchers, start the agent during application startup:
-
-```java
-import io.keploy.dedup.KeployDedupAgent;
-
-KeployDedupAgent.start();
-```
-
-Java dynamic deduplication uses JaCoCo runtime coverage. The SDK reads coverage in-process via JaCoCo's runtime API (`org.jacoco.agent.rt.RT.getAgent()`), so attaching the JaCoCo Java agent is enough: no TCP server flags, no `--pass-through-ports`.
+The Java agent is framework-agnostic. It can be attached to Spring Boot apps, Dropwizard/Jersey apps, plain executable jars, classpath-based apps, servlet/WAR-style archives, and other JVM frameworks as long as the application JVM also runs the JaCoCo agent.
 
 ```bash
-java -javaagent:/path/to/org.jacoco.agent-runtime.jar -jar target/app.jar
+java \
+  -javaagent:target/keploy-sdk.jar \
+  -javaagent:/path/to/org.jacoco.agent-runtime.jar \
+  -jar target/app.jar
 ```
 
 If the in-process API is unavailable for some reason (for example, an isolated class loader), the SDK transparently falls back to JaCoCo's TCP server mode. To force the fallback, launch JaCoCo in `tcpserver` mode and tell Keploy to leave that port alone:
 
 ```bash
-java -javaagent:/path/to/org.jacoco.agent-runtime.jar=address=127.0.0.1,port=36320,output=tcpserver \
+java \
+  -javaagent:target/keploy-sdk.jar \
+  -javaagent:/path/to/org.jacoco.agent-runtime.jar=address=127.0.0.1,port=36320,output=tcpserver \
   -jar target/app.jar
 ```
 
@@ -175,13 +181,14 @@ Build the application before running Keploy so the Java class files are availabl
 mvn clean package -DskipTests
 ```
 
-By default, the SDK scans `target/classes`, `build/classes/java/main`, and runtime classpath jars. For custom layouts or restricted Docker images, set `KEPLOY_JAVA_CLASS_DIRS` to the class directories or jars that should be analyzed.
+By default, the SDK scans Maven `target/classes`, Gradle `build/classes/java/main`, executable jars, Spring Boot `BOOT-INF/classes`, servlet `WEB-INF/classes`, and runtime classpath archives. For custom layouts or restricted Docker images, set `KEPLOY_JAVA_CLASS_DIRS` to the class directories or archives that should be analyzed.
 
 #### 3. Dockerfile Configuration (Important for Docker Users)
 
 When you use Docker or Docker Compose, make sure the final runtime image contains:
 
 - the runnable application jar,
+- the Keploy Java agent jar,
 - the JaCoCo runtime agent jar,
 - the compiled classes or the fat jar that contains the application classes.
 
@@ -189,6 +196,7 @@ For example:
 
 ```dockerfile
 COPY target/app.jar /app/app.jar
+COPY target/keploy-sdk.jar /app/keploy-sdk.jar
 COPY target/classes /app/target/classes
 COPY jacocoagent.jar /app/jacocoagent.jar
 ```
@@ -196,7 +204,7 @@ COPY jacocoagent.jar /app/jacocoagent.jar
 Then run the app with the JaCoCo agent attached:
 
 ```bash
-java -javaagent:/app/jacocoagent.jar -jar /app/app.jar
+java -javaagent:/app/keploy-sdk.jar -javaagent:/app/jacocoagent.jar -jar /app/app.jar
 ```
 
 Keploy and the Java SDK exchange per-test coverage signals over `/tmp/coverage_control.sock` and `/tmp/coverage_data.sock`. For Docker and Docker Compose, Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container so both processes see the same socket paths.
@@ -214,7 +222,7 @@ keploy test -c "docker compose up" --container-name containerName --dedup --lang
 For Native, run:
 
 ```bash
-keploy test -c "java -javaagent:/path/to/org.jacoco.agent-runtime.jar -jar target/app.jar" --dedup --language java
+keploy test -c "java -javaagent:target/keploy-sdk.jar -javaagent:/path/to/org.jacoco.agent-runtime.jar -jar target/app.jar" --dedup --language java
 ```
 
 If the SDK falls back to the JaCoCo TCP server, also pass `--pass-through-ports <jacoco-port>` so Keploy does not try to mock the coverage-control connection.

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -121,9 +121,9 @@ keploy dedup --rm
 
 #### 1. Pre-requisite
 
-Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic — Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
+Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic across Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
 
-Copy both jars into `target/` during your Maven build (do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code). Tested with JaCoCo `0.8.12`.
+Copy both jars into `target/` during your Maven build (do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code).
 
 ```xml
 <plugin>
@@ -220,7 +220,7 @@ For Native, run:
 keploy test -c "java -javaagent:target/keploy-sdk.jar -javaagent:target/jacocoagent.jar -jar target/app.jar" --dedup --language java
 ```
 
-This produces `dedupData.yaml` — a per-testcase coverage map (`testSetID/testCaseID` → executed lines per source file) Keploy uses to compute redundancy.
+This produces `dedupData.yaml`, a per-testcase coverage map (`testSetID/testCaseID` to executed lines per source file) Keploy uses to compute redundancy.
 
 ```bash
 keploy dedup

--- a/versioned_docs/version-4.0.0/running-keploy/keploy-karaf.md
+++ b/versioned_docs/version-4.0.0/running-keploy/keploy-karaf.md
@@ -35,13 +35,13 @@ curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
 
 Use `wget` to download the necessary JAR files:
 
-- [io.keploy.agent-2.0.0.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.0.jar)
+- [io.keploy.agent-2.0.2.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.2.jar)
 - [org.jacoco.agent-0.8.12-runtime.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
 
 Run the following commands to download the files:
 
 ```bash
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.0.jar
+wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.2.jar
 wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
 ```
 
@@ -54,7 +54,7 @@ wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.
 3. Add the paths of the downloaded agents under the `JAVA_OPTS` section. For example:
 
    ```bash
-   export JAVA_OPTS="-javaagent:/path/to/io.keploy.agent-2.0.0.jar"
+   export JAVA_OPTS="-javaagent:/path/to/io.keploy.agent-2.0.2.jar"
    export JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/org.jacoco.agent-0.8.12-runtime.jar=address=*,port=36320,destfile=jacoco-it.exec,output=tcpserver"
    ```
 

--- a/versioned_docs/version-4.0.0/running-keploy/keploy-karaf.md
+++ b/versioned_docs/version-4.0.0/running-keploy/keploy-karaf.md
@@ -35,13 +35,13 @@ curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
 
 Use `wget` to download the necessary JAR files:
 
-- [io.keploy.agent-2.0.1.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar)
+- [io.keploy.agent-2.0.0.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.0.jar)
 - [org.jacoco.agent-0.8.12-runtime.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
 
 Run the following commands to download the files:
 
 ```bash
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar
+wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.0.jar
 wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
 ```
 
@@ -54,7 +54,7 @@ wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.
 3. Add the paths of the downloaded agents under the `JAVA_OPTS` section. For example:
 
    ```bash
-   export JAVA_OPTS="-javaagent:/path/to/io.keploy.agent-2.0.1.jar"
+   export JAVA_OPTS="-javaagent:/path/to/io.keploy.agent-2.0.0.jar"
    export JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/org.jacoco.agent-0.8.12-runtime.jar=address=*,port=36320,destfile=jacoco-it.exec,output=tcpserver"
    ```
 

--- a/versioned_docs/version-4.0.0/server/sdk-installation/java.md
+++ b/versioned_docs/version-4.0.0/server/sdk-installation/java.md
@@ -35,7 +35,7 @@ Because the SDK is a Java agent, it is framework-agnostic. It can be attached to
 
 ## Copy the Keploy SDK and JaCoCo Agents
 
-Both jars are runtime agents — copy them into `target/` at build time. Do not add the Keploy SDK under `<dependencies>` and do not import Keploy classes from your code.
+Both jars are runtime agents. Copy them into `target/` at build time. Do not add the Keploy SDK under `<dependencies>` and do not import Keploy classes from your code.
 
 ```xml
 <plugin>
@@ -116,7 +116,7 @@ keploy dedup --rm   # removes the redundant testcases from the local Keploy test
 
 ## Docker
 
-Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container at replay time — that's how the dedup sockets are visible on both sides. Keep `/tmp` writable; do not add a conflicting `/tmp` bind mount or `tmpfs`. Restricted containers (non-root user, read-only root filesystem, dropped capabilities) work as long as `/tmp` stays writable.
+Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container at replay time, so the dedup sockets are visible on both sides. Keep `/tmp` writable; do not add a conflicting `/tmp` bind mount or `tmpfs`. Restricted containers (non-root user, read-only root filesystem, dropped capabilities) work as long as `/tmp` stays writable.
 
 ## CI Guidance
 

--- a/versioned_docs/version-4.0.0/server/sdk-installation/java.md
+++ b/versioned_docs/version-4.0.0/server/sdk-installation/java.md
@@ -118,6 +118,13 @@ keploy dedup --rm   # removes the redundant testcases from the local Keploy test
 
 Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container at replay time, so the dedup sockets are visible on both sides. Keep `/tmp` writable; do not add a conflicting `/tmp` bind mount or `tmpfs`. Restricted containers (non-root user, read-only root filesystem, dropped capabilities) work as long as `/tmp` stays writable.
 
+For shaded or uber-jar images, also copy the compiled application classes into the runtime image and set `KEPLOY_JAVA_CLASS_DIRS` so dependency classes do not participate in dedup signatures:
+
+```dockerfile
+COPY target/classes /app/classes
+ENV KEPLOY_JAVA_CLASS_DIRS=/app/classes
+```
+
 ## CI Guidance
 
 CI should run replay/test mode against checked-in Keploy test fixtures. Do not record Java dedup fixtures in the pipeline unless you intentionally want to refresh them.

--- a/versioned_docs/version-4.0.0/server/sdk-installation/java.md
+++ b/versioned_docs/version-4.0.0/server/sdk-installation/java.md
@@ -29,13 +29,13 @@ Because the SDK is a Java agent, it is framework-agnostic. It can be attached to
 ## Requirements
 
 - Java 8, 17, or 21
-- `io.keploy:keploy-sdk` version with Java-agent support
-- JaCoCo Java agent attached to the application JVM
+- `io.keploy:keploy-sdk` `2.0.6` (or newer with Java-agent support)
+- JaCoCo runtime agent (tested with `0.8.12`)
 - Keploy Enterprise with dynamic deduplication enabled
 
-## Copy the Keploy Java Agent
+## Copy the Keploy SDK and JaCoCo Agents
 
-Copy the Keploy Java agent jar during your build. Do not add it under `<dependencies>`, and do not import Keploy classes from your application code.
+Both jars are runtime agents — copy them into `target/` at build time. Do not add the Keploy SDK under `<dependencies>` and do not import Keploy classes from your code.
 
 ```xml
 <plugin>
@@ -46,9 +46,7 @@ Copy the Keploy Java agent jar during your build. Do not add it under `<dependen
     <execution>
       <id>copy-keploy-java-agent</id>
       <phase>package</phase>
-      <goals>
-        <goal>copy</goal>
-      </goals>
+      <goals><goal>copy</goal></goals>
       <configuration>
         <artifactItems>
           <artifactItem>
@@ -61,71 +59,64 @@ Copy the Keploy Java agent jar during your build. Do not add it under `<dependen
         </artifactItems>
       </configuration>
     </execution>
+    <execution>
+      <id>copy-jacoco-agent</id>
+      <phase>package</phase>
+      <goals><goal>copy</goal></goals>
+      <configuration>
+        <artifactItems>
+          <artifactItem>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>0.8.12</version>
+            <classifier>runtime</classifier>
+            <type>jar</type>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <destFileName>jacocoagent.jar</destFileName>
+          </artifactItem>
+        </artifactItems>
+      </configuration>
+    </execution>
   </executions>
 </plugin>
 ```
 
-## Run with the Keploy and JaCoCo Java Agents
+## Run with Both Agents
 
-The SDK reads coverage in-process via JaCoCo's runtime API (`org.jacoco.agent.rt.RT.getAgent()`), so attach both agents in the application JVM: the Keploy agent starts the dedup control socket, and the JaCoCo agent provides runtime coverage.
+Attach both agents in the application JVM. The Keploy agent reads coverage in-process via JaCoCo's runtime API, so order doesn't matter as long as both are present:
 
 ```bash
 java \
   -javaagent:target/keploy-sdk.jar \
-  -javaagent:/path/to/jacocoagent.jar \
+  -javaagent:target/jacocoagent.jar \
   -jar target/app.jar
 ```
 
-The SDK automatically looks for application classes in Maven `target/classes`, Gradle `build/classes/java/main`, executable jars, Spring Boot `BOOT-INF/classes`, servlet `WEB-INF/classes`, and the runtime classpath. If your compiled application classes live somewhere else, set `KEPLOY_JAVA_CLASS_DIRS` to the class directory or archive that should be analyzed:
+The SDK auto-detects application classes from Maven `target/classes`, Gradle `build/classes/java/main`, executable jars, Spring Boot `BOOT-INF/classes`, servlet `WEB-INF/classes`, and the runtime classpath. For custom layouts, point it at the right directory or archive:
 
 ```bash
 export KEPLOY_JAVA_CLASS_DIRS=/absolute/path/to/target/classes
 ```
 
-If the in-process API is unavailable in your environment, the SDK transparently falls back to JaCoCo's TCP server mode. To use the fallback explicitly, launch JaCoCo in `tcpserver` mode and configure `KEPLOY_JACOCO_HOST` / `KEPLOY_JACOCO_PORT` (defaults: `127.0.0.1:36320`):
-
-```bash
-java \
-  -javaagent:target/keploy-sdk.jar \
-  -javaagent:/path/to/jacocoagent.jar=address=127.0.0.1,port=36320,output=tcpserver \
-  -jar target/app.jar
-```
-
 ## Replay with Dedup
-
-Run Keploy in test mode with dynamic deduplication enabled:
 
 ```bash
 keploy test \
-  -c "java -javaagent:target/keploy-sdk.jar -javaagent:/path/to/jacocoagent.jar -jar target/app.jar" \
+  -c "java -javaagent:target/keploy-sdk.jar -javaagent:target/jacocoagent.jar -jar target/app.jar" \
   --dedup \
   --language java
 ```
 
-If you are using the JaCoCo TCP fallback, also pass `--pass-through-ports <jacoco-port>` so Keploy does not try to mock the coverage-control connection.
-
-After replay, run:
+This produces `dedupData.yaml` (per-testcase coverage map). Then:
 
 ```bash
-keploy dedup
+keploy dedup        # writes duplicates.yaml grouping the redundant testcases per test-set
+keploy dedup --rm   # removes the redundant testcases from the local Keploy test set
 ```
 
-To apply the dynamic deduplication cleanup:
+## Docker
 
-```bash
-keploy dedup --rm
-```
-
-## Docker and Restricted Docker
-
-Java dedup uses two Unix sockets shared between Keploy Enterprise and the Java process:
-
-- `/tmp/coverage_control.sock`
-- `/tmp/coverage_data.sock`
-
-For Docker or Docker Compose runs, Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container so both processes use the same socket paths. Do not add a conflicting `/tmp` bind mount or `tmpfs`; keep `/tmp` writable even when the root filesystem is read-only.
-
-For restricted containers, the application can run as a non-root user with dropped capabilities and `no-new-privileges` as long as the injected `/tmp` volume is shared and writable. If the SDK falls back to JaCoCo TCP mode, the JaCoCo TCP port must also be reachable from the Java process.
+Keploy injects a shared `keploy-sockets-vol:/tmp` mount into the application container and the Keploy agent container at replay time — that's how the dedup sockets are visible on both sides. Keep `/tmp` writable; do not add a conflicting `/tmp` bind mount or `tmpfs`. Restricted containers (non-root user, read-only root filesystem, dropped capabilities) work as long as `/tmp` stays writable.
 
 ## CI Guidance
 

--- a/versioned_docs/version-4.0.0/server/sdk-installation/java.md
+++ b/versioned_docs/version-4.0.0/server/sdk-installation/java.md
@@ -1,8 +1,8 @@
 ---
 id: java
-title: Java SDK for Dynamic Deduplication
+title: Java Agent for Dynamic Deduplication
 sidebar_label: Java
-description: "Configure the Keploy Java SDK for Enterprise dynamic deduplication with in-process JaCoCo coverage."
+description: "Configure the Keploy Java agent for Enterprise dynamic deduplication with in-process JaCoCo coverage."
 tags:
   - java
   - coverage
@@ -12,6 +12,7 @@ keywords:
   - JaCoCo
   - Maven
   - Spring Boot
+  - WAR
   - dynamic deduplication
 ---
 
@@ -19,59 +20,63 @@ import ProductTier from '@site/src/components/ProductTier';
 
 <ProductTier tiers="Enterprise" offerings="Self-Hosted, Dedicated" />
 
-The Java SDK is used for Enterprise dynamic deduplication during replay/test mode. It collects per-testcase Java coverage and sends it to Keploy Enterprise so duplicate testcases can be identified.
+The Keploy Java SDK is used as a Java agent for Enterprise dynamic deduplication during replay/test mode. It collects per-testcase Java coverage and sends it to Keploy Enterprise so duplicate testcases can be identified.
 
-The Java SDK does not record API traffic or mock dependencies. Record your Keploy tests separately, commit the generated test fixtures when you use them in CI, and run Java dedup during `keploy test --dedup`.
+The Java agent does not record API traffic or mock dependencies. Record your Keploy tests separately, commit the generated test fixtures when you use them in CI, and run Java dedup during `keploy test --dedup`.
+
+Because the SDK is a Java agent, it is framework-agnostic. It can be attached to Spring Boot apps, Dropwizard/Jersey apps, plain executable jars, classpath-based apps, servlet/WAR-style archives, and other JVM frameworks as long as the application JVM also runs the JaCoCo agent.
 
 ## Requirements
 
 - Java 8, 17, or 21
-- `io.keploy:keploy-sdk`
+- `io.keploy:keploy-sdk` version with Java-agent support
 - JaCoCo Java agent attached to the application JVM
 - Keploy Enterprise with dynamic deduplication enabled
 
-## Add the SDK
+## Copy the Keploy Java Agent
 
-Add the Keploy Java SDK dependency:
+Copy the Keploy Java agent jar during your build. Do not add it under `<dependencies>`, and do not import Keploy classes from your application code.
 
 ```xml
-<dependency>
-  <groupId>io.keploy</groupId>
-  <artifactId>keploy-sdk</artifactId>
-  <version>2.0.0</version>
-</dependency>
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-dependency-plugin</artifactId>
+  <version>3.6.1</version>
+  <executions>
+    <execution>
+      <id>copy-keploy-java-agent</id>
+      <phase>package</phase>
+      <goals>
+        <goal>copy</goal>
+      </goals>
+      <configuration>
+        <artifactItems>
+          <artifactItem>
+            <groupId>io.keploy</groupId>
+            <artifactId>keploy-sdk</artifactId>
+            <version>2.0.1</version>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <destFileName>keploy-sdk.jar</destFileName>
+          </artifactItem>
+        </artifactItems>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
 ```
 
-## Start the Dedup Agent
+## Run with the Keploy and JaCoCo Java Agents
 
-For Spring Boot 2 or other `javax.servlet` applications, import the middleware:
-
-```java
-import io.keploy.servlet.KeployMiddleware;
-import org.springframework.context.annotation.Import;
-
-@Import(KeployMiddleware.class)
-public class Application {
-}
-```
-
-For Spring Boot 3, Jakarta EE applications, other frameworks, or custom launchers, start the agent during application startup:
-
-```java
-import io.keploy.dedup.KeployDedupAgent;
-
-KeployDedupAgent.start();
-```
-
-## Run with the JaCoCo Java Agent
-
-The SDK reads coverage in-process via JaCoCo's runtime API (`org.jacoco.agent.rt.RT.getAgent()`), so attaching the JaCoCo agent is enough: no TCP server flags, no port choice.
+The SDK reads coverage in-process via JaCoCo's runtime API (`org.jacoco.agent.rt.RT.getAgent()`), so attach both agents in the application JVM: the Keploy agent starts the dedup control socket, and the JaCoCo agent provides runtime coverage.
 
 ```bash
-java -javaagent:/path/to/jacocoagent.jar -jar target/app.jar
+java \
+  -javaagent:target/keploy-sdk.jar \
+  -javaagent:/path/to/jacocoagent.jar \
+  -jar target/app.jar
 ```
 
-If your compiled application classes are not under `target/classes` or `build/classes/java/main`, set `KEPLOY_JAVA_CLASS_DIRS`:
+The SDK automatically looks for application classes in Maven `target/classes`, Gradle `build/classes/java/main`, executable jars, Spring Boot `BOOT-INF/classes`, servlet `WEB-INF/classes`, and the runtime classpath. If your compiled application classes live somewhere else, set `KEPLOY_JAVA_CLASS_DIRS` to the class directory or archive that should be analyzed:
 
 ```bash
 export KEPLOY_JAVA_CLASS_DIRS=/absolute/path/to/target/classes
@@ -80,7 +85,9 @@ export KEPLOY_JAVA_CLASS_DIRS=/absolute/path/to/target/classes
 If the in-process API is unavailable in your environment, the SDK transparently falls back to JaCoCo's TCP server mode. To use the fallback explicitly, launch JaCoCo in `tcpserver` mode and configure `KEPLOY_JACOCO_HOST` / `KEPLOY_JACOCO_PORT` (defaults: `127.0.0.1:36320`):
 
 ```bash
-java -javaagent:/path/to/jacocoagent.jar=address=127.0.0.1,port=36320,output=tcpserver \
+java \
+  -javaagent:target/keploy-sdk.jar \
+  -javaagent:/path/to/jacocoagent.jar=address=127.0.0.1,port=36320,output=tcpserver \
   -jar target/app.jar
 ```
 
@@ -90,7 +97,7 @@ Run Keploy in test mode with dynamic deduplication enabled:
 
 ```bash
 keploy test \
-  -c "java -javaagent:/path/to/jacocoagent.jar -jar target/app.jar" \
+  -c "java -javaagent:target/keploy-sdk.jar -javaagent:/path/to/jacocoagent.jar -jar target/app.jar" \
   --dedup \
   --language java
 ```

--- a/versioned_docs/version-4.0.0/server/sdk-installation/java.md
+++ b/versioned_docs/version-4.0.0/server/sdk-installation/java.md
@@ -54,7 +54,7 @@ Copy the Keploy Java agent jar during your build. Do not add it under `<dependen
           <artifactItem>
             <groupId>io.keploy</groupId>
             <artifactId>keploy-sdk</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.6</version>
             <outputDirectory>${project.build.directory}</outputDirectory>
             <destFileName>keploy-sdk.jar</destFileName>
           </artifactItem>


### PR DESCRIPTION
## What has changed?

Documents the Java dynamic dedup runtime-agent flow using `io.keploy:keploy-sdk:2.0.6`. The docs now say the Keploy SDK should be copied as a Java agent, not added as an application dependency, and application code should not import Keploy classes.

The Java guide covers:
- attaching the Keploy Java agent and JaCoCo agent with `-javaagent`
- in-process JaCoCo runtime coverage
- Maven/Gradle classes, Spring Boot jars, Dropwizard/Jersey apps, classpath apps, servlet/WAR layouts, and custom `KEPLOY_JAVA_CLASS_DIRS`
- Docker and restricted Docker socket requirements
- shaded/uber-jar Docker guidance: copy compiled application classes into the image and set `KEPLOY_JAVA_CLASS_DIRS` so dependency classes do not participate in dedup signatures
- running `keploy test --dedup --language java`
- Apache Karaf agent download commands for the separate S3-hosted Karaf agent distribution

This PR Resolves # NA

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

- `git diff --check -- versioned_docs/version-4.0.0/keploy-cloud/deduplication.md versioned_docs/version-4.0.0/server/sdk-installation/java.md`
- Verified the updated docs reference `2.0.6` for the `io.keploy:keploy-sdk` Maven coordinate in both `keploy-cloud/deduplication.md` and `server/sdk-installation/java.md`.
- Verified Maven metadata lists `2.0.6` as the latest/release version for `io.keploy:keploy-sdk`, and the `2.0.6` jar returns HTTP 200 from Maven Central.
- Verified the `2.0.6` jar manifest has `Premain-Class: io.keploy.dedup.KeployDedupAgent` and `Implementation-Version: 2.0.6`.
- Verified the GitHub release `v2.0.6` is marked latest and has the same jar assets attached.
- Verified the docs now include explicit Docker class-root guidance with `KEPLOY_JAVA_CLASS_DIRS=/app/classes`, matching the validated samples-java Dropwizard Docker fix.
- The Karaf doc (`running-keploy/keploy-karaf.md`) was bumped from `io.keploy.agent-2.0.1.jar` to `io.keploy.agent-2.0.2.jar`. This is a separate S3-hosted Karaf record/test agent distribution, not the Maven Central dynamic-dedup `keploy-sdk` artifact.
- Earlier branch validation covered `yarn install --frozen-lockfile`, `yarn build`, and Vale checks for the Java SDK installation and deduplication docs.

Related PRs:
- Java SDK agent: https://github.com/keploy/java-sdk/pull/183
- Samples: https://github.com/keploy/samples-java/pull/133
- Enterprise CI: https://github.com/keploy/enterprise/pull/1959

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.