### PR TITLE
Update agent-test-generation.md

### DIFF
--- a/versioned_docs/version-4.0.0/running-keploy/agent-test-generation.md
+++ b/versioned_docs/version-4.0.0/running-keploy/agent-test-generation.md
@@ -101,7 +101,7 @@ The examples below use the Keploy Cloud URL (`https://api.keploy.io`). If you're
 
 #### Claude Code
 
-Add to your Claude Code MCP settings (`~/.claude/settings.json` or project-level). Note: Claude Code requires the `type: http` field for StreamableHTTP transport (other clients do not need it).
+Add to your Claude Code MCP settings (`~/.claude.json` or project-level). Note: Claude Code requires the `type: http` field for StreamableHTTP transport (other clients do not need it).
 
 ```json
 {


### PR DESCRIPTION
This pull request makes a minor documentation fix to the Claude Code MCP settings instructions, clarifying the correct settings file name.

- Documentation update: Corrected the Claude Code MCP settings file from `~/.claude/settings.json` to `~/.claude.json` in `agent-test-generation.md` to prevent configuration confusion.