### PR TITLE
docs: update Claude Code MCP config key and API key placeholder

### DIFF
--- a/versioned_docs/version-4.0.0/running-keploy/agent-test-generation.md
+++ b/versioned_docs/version-4.0.0/running-keploy/agent-test-generation.md
@@ -106,11 +106,11 @@ Add to your Claude Code MCP settings (`~/.claude/settings.json` or project-level
 ```json
 {
   "mcpServers": {
-    "keploy": {
+    "keploy-atg": {
       "type": "http",
       "url": "https://api.keploy.io/client/v1/mcp",
       "headers": {
-        "Authorization": "Bearer kep_YOUR_API_KEY"
+        "Authorization": "Bearer <YOUR_KEPLOY_API_KEY>"
       }
     }
   }

--- a/versioned_docs/version-4.0.0/running-keploy/agent-test-generation.md
+++ b/versioned_docs/version-4.0.0/running-keploy/agent-test-generation.md
@@ -106,7 +106,7 @@ Add to your Claude Code MCP settings (`~/.claude/settings.json` or project-level
 ```json
 {
   "mcpServers": {
-    "keploy-atg": {
+    "keploy": {
       "type": "http",
       "url": "https://api.keploy.io/client/v1/mcp",
       "headers": {
@@ -133,7 +133,7 @@ Cursor supports MCP servers. Add to your Cursor MCP configuration (`.cursor/mcp.
     "keploy": {
       "url": "https://api.keploy.io/client/v1/mcp",
       "headers": {
-        "Authorization": "Bearer kep_YOUR_API_KEY"
+        "Authorization": "Bearer <YOUR_KEPLOY_API_KEY>"
       }
     }
   }
@@ -154,7 +154,7 @@ GitHub Copilot supports MCP in agent mode. Add to `.github/copilot-mcp.json` in 
     "keploy": {
       "url": "https://api.keploy.io/client/v1/mcp",
       "headers": {
-        "Authorization": "Bearer kep_YOUR_API_KEY"
+        "Authorization": "Bearer <YOUR_KEPLOY_API_KEY>"
       }
     }
   }
@@ -171,7 +171,7 @@ Antigravity (formerly Windsurf) supports MCP servers. Add to your Antigravity MC
     "keploy": {
       "serverUrl": "https://api.keploy.io/client/v1/mcp",
       "headers": {
-        "Authorization": "Bearer kep_YOUR_API_KEY"
+        "Authorization": "Bearer <YOUR_KEPLOY_API_KEY>"
       }
     }
   }
@@ -205,7 +205,7 @@ Ask your agent:
 
 > "Use the Keploy MCP tools to find apps with recorded traffic, fetch the recordings, and use them as examples to generate comprehensive API tests"
 
-The MCP endpoint uses the same API key as the REST API and accepts the same two authentication methods. The examples above use `Authorization: Bearer kep_...`, but you can also use `X-API-Key: kep_...` as an alternative (replace the `Authorization` header with `"X-API-Key": "kep_YOUR_API_KEY"` in the config). See the [Public API docs](/docs/running-keploy/public-api/) for details. All tools proxy to `/client/v1` endpoints using the caller's credentials.
+The MCP endpoint uses the same API key as the REST API and accepts the same two authentication methods. The examples above use `Authorization: Bearer kep_...`, but you can also use `X-API-Key: kep_...` as an alternative (replace the `Authorization` header with `"X-API-Key": "<YOUR_KEPLOY_API_KEY>"` in the config). See the [Public API docs](/docs/running-keploy/public-api/) for details. All tools proxy to `/client/v1` endpoints using the caller's credentials.
 
 ## Workflow
 


### PR DESCRIPTION
Renames the MCP server key from "keploy" to "keploy-atg" and updates the API key placeholder from "kep_YOUR_API_KEY" to "<YOUR_KEPLOY_API_KEY>" in the Claude Code MCP Client Configuration section.

## What has changed?

Please include a summary of the change.

This PR Resolves #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Please run npm run build and npm run serve to check if the changes are working as expected. Please include screenshots of the output of both the commands. Add screenshots/gif of the changes if possible.


## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->