### PR TITLE
fix(docs): remove /docs/ prefix from internal server installation links

### DIFF
--- a/versioned_docs/version-2.0.0/keploy-explained/mac-linux.md
+++ b/versioned_docs/version-2.0.0/keploy-explained/mac-linux.md
@@ -56,8 +56,8 @@ Congratulations! You've successfully set up Keploy natively on MacOS.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Testcases](/docs/server/installation/)
+### 🎬 [Start Capturing Testcases](/server/installation/)
 
 Begin recording your API calls and generating test cases with Keploy.
 
-#### [Back to Installation Guide](/docs/server/installation/)
+#### [Back to Installation Guide](/server/installation/)

--- a/versioned_docs/version-3.0.0/installation/linux.md
+++ b/versioned_docs/version-3.0.0/installation/linux.md
@@ -38,6 +38,6 @@ You’ve successfully installed **Keploy on Linux**.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Test Cases](/docs/server/installation/)
+### 🎬 [Start Capturing Test Cases](/server/installation/)
 
 Begin recording your API calls and automatically generate test cases with Keploy.

--- a/versioned_docs/version-3.0.0/installation/macos.md
+++ b/versioned_docs/version-3.0.0/installation/macos.md
@@ -68,7 +68,7 @@ Keploy uses eBPF to intercept API calls on network layer and generates test case
 
 ## What's Next?
 
-### 🎬 [Start Capturing Test Cases](/docs/server/installation/)
+### 🎬 [Start Capturing Test Cases](/server/installation/)
 
 Begin recording your API calls and automatically generate test cases with Keploy.
 

--- a/versioned_docs/version-3.0.0/installation/windows.md
+++ b/versioned_docs/version-3.0.0/installation/windows.md
@@ -31,7 +31,6 @@ If you already have WSL, Go to Step 2.
 1. **Enable WSL**
 
    Make sure you’re on:
-
    - **Windows 10** (version 2004 or later, build 19041+)
    - **Windows 11**
 
@@ -61,7 +60,7 @@ If you already have WSL, Go to Step 2.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Test Cases](/docs/server/installation/)
+### 🎬 [Start Capturing Test Cases](/server/installation/)
 
 Begin recording your API calls and automatically generate test cases with Keploy.
 

--- a/versioned_docs/version-3.0.0/keploy-explained/mac-linux.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/mac-linux.md
@@ -56,8 +56,8 @@ Congratulations! You've successfully set up Keploy natively on MacOS.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Testcases](/docs/server/installation/)
+### 🎬 [Start Capturing Testcases](/server/installation/)
 
 Begin recording your API calls and generating test cases with Keploy.
 
-#### [Back to Installation Guide](/docs/server/installation/)
+#### [Back to Installation Guide](/server/installation/)

--- a/versioned_docs/version-3.0.0/keploy-explained/windows-wsl.md
+++ b/versioned_docs/version-3.0.0/keploy-explained/windows-wsl.md
@@ -38,8 +38,8 @@ Congratulations! You've successfully set up Keploy natively on Windows.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Testcases](/docs/server/installation/)
+### 🎬 [Start Capturing Testcases](/server/installation/)
 
 Begin recording your API calls and generating test cases with Keploy.
 
-#### [Back to Installation Guide](/docs/server/installation/)
+#### [Back to Installation Guide](/server/installation/)

--- a/versioned_docs/version-4.0.0/installation/linux.md
+++ b/versioned_docs/version-4.0.0/installation/linux.md
@@ -38,6 +38,6 @@ You’ve successfully installed **Keploy on Linux**.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Test Cases](/docs/server/installation/)
+### 🎬 [Start Capturing Test Cases](/server/installation/)
 
 Begin recording your API calls and automatically generate test cases with Keploy.

--- a/versioned_docs/version-4.0.0/installation/macos.md
+++ b/versioned_docs/version-4.0.0/installation/macos.md
@@ -68,7 +68,7 @@ Keploy uses eBPF to intercept API calls on network layer and generates test case
 
 ## What's Next?
 
-### 🎬 [Start Capturing Test Cases](/docs/server/installation/)
+### 🎬 [Start Capturing Test Cases](/server/installation/)
 
 Begin recording your API calls and automatically generate test cases with Keploy.
 

--- a/versioned_docs/version-4.0.0/installation/windows.md
+++ b/versioned_docs/version-4.0.0/installation/windows.md
@@ -61,7 +61,7 @@ If you already have WSL, Go to Step 2.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Test Cases](/docs/server/installation/)
+### 🎬 [Start Capturing Test Cases](/server/installation/)
 
 Begin recording your API calls and automatically generate test cases with Keploy.
 

--- a/versioned_docs/version-4.0.0/keploy-explained/mac-linux.md
+++ b/versioned_docs/version-4.0.0/keploy-explained/mac-linux.md
@@ -57,8 +57,8 @@ Congratulations! You've successfully set up Keploy natively on MacOS.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Testcases](/docs/server/installation/)
+### 🎬 [Start Capturing Testcases](/server/installation/)
 
 Begin recording your API calls and generating test cases with Keploy.
 
-#### [Back to Installation Guide](/docs/server/installation/)
+#### [Back to Installation Guide](/server/installation/)

--- a/versioned_docs/version-4.0.0/keploy-explained/windows-wsl.md
+++ b/versioned_docs/version-4.0.0/keploy-explained/windows-wsl.md
@@ -39,8 +39,8 @@ Congratulations! You've successfully set up Keploy natively on Windows.
 
 ## What's Next?
 
-### 🎬 [Start Capturing Testcases](/docs/server/installation/)
+### 🎬 [Start Capturing Testcases](/server/installation/)
 
 Begin recording your API calls and generating test cases with Keploy.
 
-#### [Back to Installation Guide](/docs/server/installation/)
+#### [Back to Installation Guide](/server/installation/)


### PR DESCRIPTION
## What has changed?

Replaces `/docs/server/installation/` with `/server/installation/` in 16 internal Markdown links across `versioned_docs/version-2.0.0/`, `version-3.0.0/`, and `version-4.0.0/`. Inside Docusaurus versioned docs, internal links resolve through the active version's namespace, so the `/docs/` prefix is wrong and surfaces as broken-anchor warnings during `npm run build`.

External links to `https://keploy.io/docs/server/...` are intentionally left alone because those resolve against the deployed site, where the `/docs/` segment is part of the public URL.

Refs https://github.com/keploy/keploy/issues/3649 (the issue lives in keploy/keploy because keploy/docs does not use issues; #3649 below is the keploy/keploy issue number, not a keploy/docs reference).

Refs #3649

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

`grep -rn '](\/docs\/server\/' versioned_docs --include='*.md'` returns no matches after the change, where it returned 16 before. The 4 remaining `/docs/server/` references are all `https://keploy.io/...` external URLs and are unchanged.

`prettier --check` against the touched files passes; the version-3.0.0/installation/windows.md hunk includes a single blank-line removal that prettier auto-applied while writing my edits, which keeps the file in compliance with the project's prettier config rather than fighting it.

I have not been able to run a full `npm run build` here because the dev server install pulls a large dependency tree, but the file-level link rewrite is mechanical and covers exactly the broken-anchor pattern listed in the issue.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.