### PR TITLE
docs(java-dedup): clarify pom.xml changes are optional

### DIFF
--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -123,11 +123,11 @@ keploy dedup --rm
 
 Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic across Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
 
-Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode either at compile time or while classes load, so no source code or `pom.xml` changes are required to enable dedup. 
+Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode either at compile time or while classes load, so no source code or `pom.xml` changes are required to enable dedup.
 
 You only need `keploy-sdk.jar` and `jacocoagent.jar` available on disk wherever you reference them with `-javaagent:` at runtime. Fetch them in whichever way fits your workflow:
 
-**Option A**, one-off fetch with the Maven CLI: 
+**Option A**, one-off fetch with the Maven CLI:
 
 ```bash
 mvn dependency:copy \

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -123,11 +123,11 @@ keploy dedup --rm
 
 Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic across Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
 
-Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode at compile time and do not retransform classes at load time, so **no source code or `pom.xml` changes are required** to enable dedup. Do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code.
+Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode either at compile time or while classes load, so **no source code or `pom.xml` changes are required** to enable dedup. Do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code.
 
 You only need `keploy-sdk.jar` and `jacocoagent.jar` available on disk wherever you reference them with `-javaagent:` at runtime. Fetch them in whichever way fits your workflow:
 
-**Option A — one-off fetch with the Maven CLI (no `pom.xml` edit):**
+**Option A**, one-off fetch with the Maven CLI (no `pom.xml` edit):
 
 ```bash
 mvn dependency:copy \
@@ -139,9 +139,11 @@ mvn dependency:copy \
   -DoutputDirectory=target -Dmdep.stripVersion=true
 ```
 
-**Option B — direct download from Maven Central (no Maven required):**
+**Option B**, direct download from Maven Central (no Maven required):
 
 ```bash
+mkdir -p target
+
 curl -L -o target/keploy-sdk.jar \
   https://repo.maven.apache.org/maven2/io/keploy/keploy-sdk/2.0.6/keploy-sdk-2.0.6.jar
 
@@ -149,7 +151,7 @@ curl -L -o target/jacocoagent.jar \
   https://repo.maven.apache.org/maven2/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar
 ```
 
-**Option C — let your Maven build copy them automatically.** If you'd rather Maven fetch the agents during your normal build, add the following plugin block to your `pom.xml`. It runs at the `package` phase and only copies the two JARs alongside your app jar — it does not alter the compile classpath, your application bytecode, or any source file:
+**Option C**, let your Maven build copy them automatically. If you'd rather Maven fetch the agents during your normal build, add the following plugin block to your `pom.xml`. It runs at the `package` phase and only copies the two JARs alongside your app jar; it does not alter the compile classpath, your application bytecode, or any source file:
 
 ```xml
 <plugin>

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -123,7 +123,33 @@ keploy dedup --rm
 
 Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic across Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
 
-Copy both jars into `target/` during your Maven build (do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code).
+Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode at compile time and do not retransform classes at load time, so **no source code or `pom.xml` changes are required** to enable dedup. Do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code.
+
+You only need `keploy-sdk.jar` and `jacocoagent.jar` available on disk wherever you reference them with `-javaagent:` at runtime. Fetch them in whichever way fits your workflow:
+
+**Option A — one-off fetch with the Maven CLI (no `pom.xml` edit):**
+
+```bash
+mvn dependency:copy \
+  -Dartifact=io.keploy:keploy-sdk:2.0.6 \
+  -DoutputDirectory=target -Dmdep.stripVersion=true
+
+mvn dependency:copy \
+  -Dartifact=org.jacoco:org.jacoco.agent:0.8.12:jar:runtime \
+  -DoutputDirectory=target -Dmdep.stripVersion=true
+```
+
+**Option B — direct download from Maven Central (no Maven required):**
+
+```bash
+curl -L -o target/keploy-sdk.jar \
+  https://repo.maven.apache.org/maven2/io/keploy/keploy-sdk/2.0.6/keploy-sdk-2.0.6.jar
+
+curl -L -o target/jacocoagent.jar \
+  https://repo.maven.apache.org/maven2/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar
+```
+
+**Option C — let your Maven build copy them automatically.** If you'd rather Maven fetch the agents during your normal build, add the following plugin block to your `pom.xml`. It runs at the `package` phase and only copies the two JARs alongside your app jar — it does not alter the compile classpath, your application bytecode, or any source file:
 
 ```xml
 <plugin>

--- a/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/deduplication.md
@@ -123,11 +123,11 @@ keploy dedup --rm
 
 Java dynamic deduplication uses JaCoCo runtime coverage. Attach the Keploy Java agent to emit per-test coverage signals, and attach the JaCoCo runtime agent so the SDK can read the coverage data. The Java agent is framework-agnostic across Spring Boot, Dropwizard/Jersey, plain executable jars, classpath-based apps, servlet/WAR archives, etc.
 
-Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode either at compile time or while classes load, so **no source code or `pom.xml` changes are required** to enable dedup. Do not add the Keploy SDK as an application dependency, and do not import Keploy classes from your code.
+Both agents attach at JVM startup via `-javaagent:`. They do not modify your application bytecode either at compile time or while classes load, so no source code or `pom.xml` changes are required to enable dedup. 
 
 You only need `keploy-sdk.jar` and `jacocoagent.jar` available on disk wherever you reference them with `-javaagent:` at runtime. Fetch them in whichever way fits your workflow:
 
-**Option A**, one-off fetch with the Maven CLI (no `pom.xml` edit):
+**Option A**, one-off fetch with the Maven CLI: 
 
 ```bash
 mvn dependency:copy \


### PR DESCRIPTION
## What has changed?

The "For Java Applications" section under `keploy-cloud/deduplication.md` previously read as if the `maven-dependency-plugin` block was a required step to enable dynamic deduplication. That framing prompted users to ask whether the change forced them to recompile their app or alter their build pipeline. It does not — the Keploy Java agent is a pure `-javaagent` (`Premain-Class` only, `Can-Redefine-Classes=false`, `Can-Retransform-Classes=false`) that attaches at JVM startup and does not modify application bytecode at compile time or retransform classes at load time.

This PR rewrites the **Pre-requisite** subsection of the Java instructions to make that explicit and to present three equivalent ways to obtain the agent JARs:

- **Option A** — one-off fetch with `mvn dependency:copy` (no `pom.xml` edit)
- **Option B** — direct `curl` from Maven Central (no Maven required)
- **Option C** — the existing `maven-dependency-plugin` block, now framed as an optional convenience for users who prefer their build to copy the JARs automatically

Everything from "Run the app with both agents attached" onward (build configuration, Dockerfile, run commands) is unchanged.

This PR Resolves #(no issue — surfaced via user question)

## Type of change

- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

This change was driven by an empirical end-to-end run against `samples-java/java-dedup` on macOS (Docker Desktop 28.5.1, Keploy Enterprise 3.2.74-ff7ac305):

1. Restored `samples-java/java-dedup/pom.xml` to its checked-in state and confirmed `diff` was empty against the original throughout.
2. Built with `mvn -B -DskipTests clean package` — **no `-Dkeploy.agent.version=…`**, so the sample's `copy-keploy-agent` profile never activated. The build produced `target/java-dedup.jar` and `target/jacocoagent.jar` only; no `keploy-sdk.jar`.
3. Fetched the agent purely out-of-band via `mvn dependency:copy -Dartifact=io.keploy:keploy-sdk:2.0.6 -DoutputDirectory=target -Dmdep.stripVersion=true` — no `pom.xml` edit.
4. `docker compose build` produced the runtime image with both agent JARs and the existing entrypoint.
5. `keploy test -c "docker compose up" --container-name "dedup-java" --dedup --language java --delay 15 --disableMockUpload --disableReportUpload` → **400/400 testcases passed across all four testsets**.
6. `keploy dedup --path .` → produced `duplicates.yaml`; Keploy reported **18 unique / 381 duplicate** out of 399 testcases analyzed.
7. `diff pom.xml pom.xml.bak` → empty (pom.xml byte-for-byte unchanged the entire time).

I have **not** run `npm run build` / `npm run serve` against this branch, since the change is markdown content only (no sidebar, frontmatter, link, or config change) and limited to a single existing file. Happy to attach screenshots from a local Docusaurus build if reviewers want them — just ping.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.