### PR TITLE
docs(k8s-proxy): use ns.deployment form in branch-merge example

### DIFF
--- a/versioned_docs/version-4.0.0/quickstart/k8s-proxy-developer-workflow.md
+++ b/versioned_docs/version-4.0.0/quickstart/k8s-proxy-developer-workflow.md
@@ -193,9 +193,11 @@ jobs:
           KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}
         run: |
           keploy cloud branch-merge \
-            --app <app-id> \
+            --app <namespace>.<deployment> \
             --branch ${{ github.head_ref }}
 ```
+
+`--app` accepts either a `namespace.deployment` identifier (k8s-proxy apps, e.g. `prod.orders`) or a raw app UUID (non-proxy apps). The same form you use for `keploy upload test-set` and `keploy cloud replay` works here.
 
 `keploy cloud branch-merge` is idempotent—running it twice on an already-merged branch is a no-op. If the PR was closed without merging, the `if:` guard above keeps the job from firing.
 


### PR DESCRIPTION
## Summary
- Switch the branch-merge example in the k8s-proxy developer-workflow page to use `<namespace>.<deployment>` instead of the UUID-shaped `<app-id>` placeholder, since the k8s-proxy form is the primary use case for that command.
- Add a one-line note clarifying that `--app` accepts both forms (UUID or `namespace.deployment`), matching the CLI flag's actual behavior in `cmd/enterprise/cli/cloud.go:285`.

## Why
- `keploy cloud branch-merge` only registers `--app` (there's no `--cloud-app-id` on this subcommand), and the flag accepts either a UUID or a `namespace.deployment` identifier — same shape `keploy upload test-set` and `keploy cloud replay` use.
- The previous `<app-id>` placeholder read as UUID-only and didn't surface the k8s-proxy form that most users of this workflow page reach for.

## Test plan
- [ ] Render the page locally (`yarn start`) and confirm the YAML block is formatted correctly.
- [ ] Vale lint passes on the changed lines.