### PR TITLE
docs(time-freezing): correct the Go version claim — works on all supported Go releases

### DIFF
--- a/versioned_docs/version-3.0.0/keploy-cloud/time-freezing.md
+++ b/versioned_docs/version-3.0.0/keploy-cloud/time-freezing.md
@@ -50,11 +50,11 @@ For Docker-based applications, you'll need to make a few adjustments to your Doc
 uname -a
 ```
 
-2. Download the the appropriate time freeze agent for your architecture & set the `LD_PRELOAD` Environment Variable in your Dockerfile
+2. Download the appropriate time freeze agent for your architecture & set the `LD_PRELOAD` Environment Variable in your Dockerfile
 
 ### For Golang(Go) Applications -
 
-> Note: Time freezing is only supported till go **1.22.x** version.
+> Note: Time freezing works on every Go version that supports the `faketime` build tag, i.e. all currently supported Go releases. The mechanism is build-time (the `-tags=faketime` flag swaps Go's `time` package to read from a runtime agent file instead of the OS clock), so it's not tied to any specific Go version.
 
 #### amd64/x86_64 🖥️
 

--- a/versioned_docs/version-4.0.0/keploy-cloud/time-freezing.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/time-freezing.md
@@ -51,11 +51,11 @@ For Docker-based applications, you'll need to make a few adjustments to your Doc
 uname -a
 ```
 
-2. Download the the appropriate time freeze agent for your architecture & set the `LD_PRELOAD` Environment Variable in your Dockerfile
+2. Download the appropriate time freeze agent for your architecture & set the `LD_PRELOAD` Environment Variable in your Dockerfile
 
 ### For Golang(Go) Applications -
 
-> Note: Time freezing is only supported till go **1.22.x** version.
+> Note: Time freezing works on every Go version that supports the `faketime` build tag, i.e. all currently supported Go releases. The mechanism is build-time (the `-tags=faketime` flag swaps Go's `time` package to read from a runtime agent file instead of the OS clock), so it's not tied to any specific Go version.
 
 #### amd64/x86_64 🖥️
 


### PR DESCRIPTION
## Summary

The two current time-freezing pages (versions 3.0.0 and 4.0.0) both carried the same incorrect note:

> Note: Time freezing is only supported till go **1.22.x** version.

That's wrong. The mechanism is build-time — `-tags=faketime` is a Go build tag that swaps `runtime.now()` to read from the freeze-time agent file instead of the OS clock — so it applies to any Go version that supports the build tag, which is every currently-supported release.

## How this surfaced

An AI agent walking the Keploy MCP onboarding flow read the existing note, propagated the false "Requires Go 1.22.x" comment into a user's Dockerfile, and would have rejected newer Go versions. Updating the docs so the next agent (or human) reading the page gets accurate guidance.

## Change

One-line replacement in versions 3.0.0 and 4.0.0. New text states the build-tag mechanism explicitly so a reader understands why the Go-version constraint doesn't apply:

> Note: Time freezing works on every Go version that supports the `faketime` build tag — i.e. all currently-supported Go releases. The mechanism is build-time (the `-tags=faketime` flag swaps Go's `time` package to read from a runtime agent file instead of the OS clock), so it's not tied to any specific Go version.

Version 2.0.0 is intentionally left untouched (historical / archived).

## Test plan

- [ ] Docusaurus build is green (no broken links / lint).
- [ ] Live site preview shows the new note on the version-3.0.0 and version-4.0.0 time-freezing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)