### PR TITLE
docs(installation): note that the one-click installer defaults to Community Edition

### DIFF
--- a/versioned_docs/version-4.0.0/concepts/installation.md
+++ b/versioned_docs/version-4.0.0/concepts/installation.md
@@ -2,12 +2,13 @@
 id: installation
 title: Installation Overview
 sidebar_label: Installation
-description: "Install Keploy using the CLI or manually — quick setup guide with platform requirements for Linux, macOS, and Windows."
+description: "Install Keploy using the CLI or manually — quick setup guide with platform requirements for Linux, macOS, and Windows. By default, this installs the Keploy Community Edition."
 tags:
   - linux
   - ebpf
   - installation
   - install
+  - community-edition
 keywords:
   - ebpf
   - installation
@@ -19,6 +20,8 @@ keywords:
   - Auto Testcase generation
   - installation-guide
   - server-setup
+  - keploy community edition
+  - community edition
 ---
 
 import PlatformRequirements from '../concepts/platform-requirements.md'
@@ -27,6 +30,8 @@ import PlatformRequirements from '../concepts/platform-requirements.md'
 
 # Installation Overview
 
+By default, this guide installs the **Keploy Community Edition**. The install command below is the same for everyone — once you sign in, Keploy detects your plan and enables Community Edition features by default, or Pro / Enterprise features if your account has access to them.
+
 ## Quick Installation Using CLI
 
 Let's get started by setting up the Keploy alias with this command:
@@ -34,6 +39,10 @@ Let's get started by setting up the Keploy alias with this command:
 ```bash
  curl --silent -O -L https://keploy.io/install.sh && source install.sh
 ```
+
+:::info
+By default, this command installs the **Keploy Community Edition**. Your plan (Community, Pro, or Enterprise) is determined after you log in.
+:::
 
 You should see something like this:
 
@@ -65,7 +74,7 @@ Flags:
 Use "keploy [command] --help" for more information about a command.
 ```
 
-🎉 Wohoo! You are all set to use Keploy.
+🎉 Wohoo! You are all set to use Keploy (defaults to the **Community Edition** until you sign in with a paid plan).
 
 ## Other Installation Methods
 

--- a/versioned_docs/version-4.0.0/concepts/installation.md
+++ b/versioned_docs/version-4.0.0/concepts/installation.md
@@ -30,7 +30,7 @@ import PlatformRequirements from '../concepts/platform-requirements.md'
 
 # Installation Overview
 
-By default, this guide installs the **Keploy Community Edition**. The install command below is the same for everyone — once you sign in, Keploy detects your plan and enables Community Edition features by default, or Pro / Enterprise features if your account has access to them.
+By default, this guide installs the **Keploy Community Edition**. The install command below is the same for everyone. Once you sign in, Keploy detects your plan and enables Community Edition features by default, or Pro / Enterprise features if your account has access to them.
 
 ## Quick Installation Using CLI
 
@@ -74,7 +74,7 @@ Flags:
 Use "keploy [command] --help" for more information about a command.
 ```
 
-🎉 Wohoo! You are all set to use Keploy (defaults to the **Community Edition** until you sign in with a paid plan).
+🎉 Wohoo! You are all set to use Keploy.
 
 ## Other Installation Methods
 

--- a/versioned_docs/version-4.0.0/server/installation.md
+++ b/versioned_docs/version-4.0.0/server/installation.md
@@ -3,13 +3,14 @@ id: install
 title: Keploy Local Installation
 sidebar_label: Local
 hide_title: true
-description: "Install Keploy locally on Linux using eBPF — record API calls, generate test cases, and replay tests with one command."
+description: "Install Keploy locally on Linux using eBPF — record API calls, generate test cases, and replay tests with one command. By default, this installs the Keploy Community Edition."
 tags:
   - hello-world
   - linux
   - ebpf
   - installation
   - install
+  - community-edition
 keywords:
   - hello-world
   - ebpf
@@ -21,9 +22,11 @@ keywords:
   - Auto Testcase generation
   - installation-guide
   - server-setup
+  - keploy community edition
+  - community edition
 ---
 
-Keploy uses eBPF to intercept API calls on network layer and generates test cases and mocks/stubs.
+Keploy uses eBPF to intercept API calls on network layer and generates test cases and mocks/stubs. By default, the one-click install command below installs the **Keploy Community Edition** — your plan (Community, Pro, or Enterprise) is determined after you log in.
 
 import HowTo from '@site/src/components/HowTo';
 import InstallationGuide from '../concepts/installation.md'

--- a/versioned_docs/version-4.0.0/server/installation.md
+++ b/versioned_docs/version-4.0.0/server/installation.md
@@ -26,7 +26,7 @@ keywords:
   - community edition
 ---
 
-Keploy uses eBPF to intercept API calls on network layer and generates test cases and mocks/stubs. By default, the one-click install command below installs the **Keploy Community Edition** — your plan (Community, Pro, or Enterprise) is determined after you log in.
+Keploy uses eBPF to intercept API calls on network layer and generates test cases and mocks/stubs. By default, the one-click install command below installs the **Keploy Community Edition**. Your plan (Community, Pro, or Enterprise) is determined after you log in.
 
 import HowTo from '@site/src/components/HowTo';
 import InstallationGuide from '../concepts/installation.md'


### PR DESCRIPTION
## Summary
- Add a clear note on `concepts/installation.md` and `server/installation.md` stating that the one-click `curl install.sh` command installs the **Keploy Community Edition** by default.
- Clarify that the installer is the same for everyone — the actual plan (Community / Pro / Enterprise) is determined after login.
- Update frontmatter description, tags, and keywords on both pages so search engines and LLMs scraping the page reliably surface this fact.

## Test plan
- [ ] `npm run start` and visit `/docs/server/installation/` — confirm the new intro line and `:::info` admonition render correctly.
- [ ] Visit `/docs/concepts/installation/` and the quickstart pages that embed `InstallationGuide` — confirm the note appears consistently.
- [ ] `npm run build` succeeds with no broken-link warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)