### PR TITLE
docs(macos-install): restore Homebrew install as option 2

### DIFF
--- a/versioned_docs/version-4.0.0/server/macos/installation.md
+++ b/versioned_docs/version-4.0.0/server/macos/installation.md
@@ -50,7 +50,7 @@ url: "#install-with-homebrew",
 
 There are two ways to install Keploy on macOS:
 
-1. [One-click install](#one-click-install-keploy) — **recommended**.
+1. **Recommended:** [One-click install](#one-click-install-keploy).
 2. [Install with Homebrew](#install-with-homebrew).
 
 For users who need eBPF support, a [manual setup with Docker Desktop or Colima](#manual-setup) is also available.

--- a/versioned_docs/version-4.0.0/server/macos/installation.md
+++ b/versioned_docs/version-4.0.0/server/macos/installation.md
@@ -2,7 +2,7 @@
 id: installation
 title: macOS Installation
 sidebar_label: macOS
-description: "Install Keploy on macOS with the one-click curl installer. Docker Desktop and Colima setups are also supported for eBPF testing."
+description: "Install Keploy on macOS with the one-click curl installer or Homebrew. Docker Desktop and Colima setups are also supported for eBPF testing."
 tags:
   - hello-world
   - macos
@@ -20,35 +20,40 @@ keywords:
   - guide
   - api
   - docker
+  - homebrew
+  - brew install keploy
 ---
 
 import HowTo from '@site/src/components/HowTo';
 
 <HowTo
 name="Install Keploy on macOS"
-description="Install the Keploy CLI on macOS using the one-click curl installer."
+description="Install the Keploy CLI on macOS using the one-click curl installer or Homebrew."
 totalTime="PT5M"
 estimatedCost={{currency: "USD", value: "0"}}
-tools={["bash", "curl"]}
+tools={["bash", "curl", "Homebrew (optional)"]}
 supplies={["A macOS machine"]}
 visible={false}
 steps={[
 {
-name: "One-click install",
+name: "One-click install (recommended)",
 text: "Run: curl --silent -O -L https://keploy.io/install.sh && source install.sh",
 url: "#one-click-install-keploy",
 },
-/* Homebrew install temporarily disabled — the keploy/tap formula has known issues being resolved. Re-enable this step (and the "Install with Homebrew" section below) once the tap is fixed.
 {
 name: "Install with Homebrew",
 text: "Run: brew install keploy/tap/keploy",
 url: "#install-with-homebrew",
 },
-*/
 ]}
 />
 
-The recommended way to install Keploy on macOS is the **one-click curl installer**. For users who need eBPF support, a [manual setup with Docker Desktop or Colima](#manual-setup) is also available.
+There are two ways to install Keploy on macOS:
+
+1. [One-click install](#one-click-install-keploy) — **recommended**.
+2. [Install with Homebrew](#install-with-homebrew).
+
+For users who need eBPF support, a [manual setup with Docker Desktop or Colima](#manual-setup) is also available.
 
 ## One-click install Keploy
 
@@ -58,10 +63,7 @@ Run the following command in your terminal:
  curl --silent -O -L https://keploy.io/install.sh && source install.sh
 ```
 
-<!--
 ## Install with Homebrew
-
-_Homebrew installation is temporarily disabled while we resolve known issues with the `keploy/tap` formula. Once fixed, this section will be restored._
 
 If you prefer [Homebrew](https://brew.sh/), install Keploy from the official Keploy tap:
 
@@ -74,7 +76,6 @@ Verify the install:
 ```shell
 keploy --version
 ```
--->
 
 ## Manual Setup
 


### PR DESCRIPTION
## Summary

Follow-up to #867. Now that the `keploy/tap` Homebrew formula is expected to work, restore `brew install keploy/tap/keploy` as a documented option on the macOS install page.

- Re-enable the **Install with Homebrew** HowTo JSON-LD step (step 2). Curl one-click stays as step 1 / recommended.
- Re-add the visible **`## Install with Homebrew`** section.
- Restore the two-option intro list; Manual Setup (Docker Desktop / Colima) stays below as the eBPF fallback.
- Put `homebrew` / `brew install keploy` back in frontmatter keywords + the page description so Google indexes brew as a supported install path again.

## Test plan

- [ ] `npm run build` succeeds (verified locally — no MDX errors).
- [ ] Verified `brew install keploy/tap/keploy` actually works against the current state of the `keploy/homebrew-keploy` tap before merge.
- [ ] Preview deployment: `/docs/server/macos/installation/` renders both One-click install and Install with Homebrew sections.
- [ ] After merge: request re-indexing of `/docs/server/macos/installation/` in Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)