### PR TITLE
feat: add internal blog links to regression-testing glossary page

### DIFF
--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/regression-testing.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/regression-testing.md
@@ -12,7 +12,7 @@ keywords:
 
 ## What is regression testing?
 
-Regression testing is a type of software testing that ensures that changes made to a software application do not negatively impact existing functionality. It is typically performed after a new feature is added, a bug is fixed, or a configuration change is made.
+[Regression testing](https://keploy.io/blog/community/regression-testing-an-introductory-guide) is a type of software testing that ensures that changes made to a software application do not negatively impact existing functionality. It is typically performed after a new feature is added, a bug is fixed, or a configuration change is made.
 
 Regression testing can be performed manually or using automated tools. Manual regression testing involves re-running a subset of test cases that have been previously executed to ensure that they still pass. Automated regression testing uses software to execute test cases automatically, which can save time and resources.
 
@@ -44,6 +44,8 @@ Regression testing involves re-running previously executed test cases to ensure 
 Overall, by leveraging Keploy's testing capabilities and integrating it into your regression testing process, you can ensure the stability and reliability of your software by detecting and preventing regression bugs effectively.
 
 ## Key differences between manual regression testing and automated regression testing:
+
+Understanding the difference between manual and [automated regression testing](https://keploy.io/blog/community/automated-regression-testing) helps teams choose the right approach for their context. The table below breaks down the key factors across speed, cost, scalability, and maintenance.
 
 | Feature                  | Manual Regression Testing                                 | Automated Regression Testing                                                     |
 | ------------------------ | --------------------------------------------------------- | -------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Add internal link on "Regression testing" in the opening paragraph of the regression-testing glossary page, pointing to the introductory blog post
- Add introductory sentence with an "automated regression testing" internal link before the manual-vs-automated comparison table
- Both links are in statically rendered markdown (Docusaurus SSR), satisfying SEO crawl requirements

## Not Implemented

**Canonical URL on glossary page** -  adding a `<link rel="canonical">` on the docs glossary page pointing to the blog post. Not implemented because setting the canonical of a docs page to a blog URL instructs search engines to de-index the docs page entirely in favour of the blog. This is a high-impact, irreversible SEO decision that needs explicit confirmation before implementation. Can implement again once we have had a discussion internally to confirm this

**noindex on `/1.0.0/` regression testing page** - adding a noindex tag to `https://keploy.io/docs/1.0.0/concepts/reference/glossary/Regression-Testing/`. Not implemented because `noIndex: true` is already set for the entire v1.0.0 version in `docusaurus.config.js`, which automatically injects `<meta name="robots" content="noindex, nofollow">` into every page under that version. No code change is needed.

- Reference sheet: https://docs.google.com/spreadsheets/d/1Z3lyUoyTRhtM1oiQfJh7V9v0E3zBi6DXqEVL0GMCFA4/edit?usp=sharing