### PR TITLE
feat: canonical tags and internal links to 2 pages

### DIFF
--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/black-box-testing.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/black-box-testing.md
@@ -18,6 +18,11 @@ keywords:
   - what is black box testing
   - keploy
   - regression testing
+head:
+  - tag: link
+    attrs:
+      rel: canonical
+      href: https://keploy.io/blog/community/black-box-testing-and-white-box-testing-a-complete-guide
 ---
 
 Black-box testing is a software testing method where the tester evaluates the functionality of an application without having access to its internal code structure, algorithms, or implementation details. Instead, the tester interacts with the software through its user interface or exposed APIs, treating it as a "black box" whose internal workings are not visible or known.
@@ -30,7 +35,7 @@ The focus lies solely on examining the software's external behavior, inputs, out
 
 This testing approach is essential for several reasons:
 
-- **Independence from Internal Implementation:** Black-box testing allows testers to assess the software's functionality without needing knowledge of its internal workings. This independence ensures that the evaluation remains unbiased and realistic, as it mimics the perspective of end-users who are unaware of the software's internal structure.
+- **Independence from Internal Implementation:** [Black-box testing](https://keploy.io/blog/community/black-box-testing-and-white-box-testing-a-complete-guide) allows testers to assess the software's functionality without needing knowledge of its internal workings. This independence ensures that the evaluation remains unbiased and realistic, as it mimics the perspective of end-users who are unaware of the software's internal structure.
 
 - **User-Centric Perspective**: By concentrating on the software's external behavior, black-box testing aligns closely with the user's experience. It helps identify issues that impact user interactions, such as usability flaws, incorrect outputs, or unexpected behaviors, leading to a more user-centric approach to quality assurance.
 

--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/regression-testing.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/regression-testing.md
@@ -8,6 +8,11 @@ tags:
   - Glossary
 keywords:
   - API
+head:
+  - tag: link
+    attrs:
+      rel: canonical
+      href: https://keploy.io/blog/community/regression-testing-an-introductory-guide
 ---
 
 ## What is regression testing?

--- a/versioned_docs/version-4.0.0/running-keploy/best-practices-api-testing.md
+++ b/versioned_docs/version-4.0.0/running-keploy/best-practices-api-testing.md
@@ -21,7 +21,7 @@ keywords:
 
 ## 🛠️ Best Practices in API Testing
 
-API testing ensures the reliability, security, and performance of your application's backend services. To build robust, scalable test suites, here are the best practices you should follow:
+[API testing](https://keploy.io/blog/community/what-is-api-testing) ensures the reliability, security, and performance of your application's backend services. To build robust, scalable test suites, here are the best practices you should follow:
 
 ### ✅ 1. Define Clear Test Objectives
 


### PR DESCRIPTION
## SEO: Canonical tags and internal blog links for glossary and best-practices pages

- Add `rel=canonical` on regression-testing glossary → regression testing introductory guide blog
- Add `rel=canonical` on black-box-testing glossary → black-box vs white-box complete guide blog
- Add internal link with anchor "Black-box testing" in the "Independence from Internal Implementation" bullet on black-box-testing page
- Add internal link with anchor "API testing" at first body mention on best-practices-api-testing page → what-is-api-testing blog

All canonical tags use Docusaurus `head:` frontmatter (server-side rendered, visible in raw page source).
