### PR TITLE
fix(docitem): render frontMatter.head tags so custom canonicals reach built HTML

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -237,6 +237,12 @@ export default function DocItem(props) {
             {JSON.stringify(articleSchema)}
           </script>
         )}
+        {Array.isArray(frontMatter.head) &&
+          frontMatter.head.map((headTag, i) => {
+            if (!headTag?.tag) return null;
+            const {tag: tagName, attrs = {}} = headTag;
+            return React.createElement(tagName, {key: i, ...attrs});
+          })}
       </Head>
       <div className="row">
         <div


### PR DESCRIPTION
Follow-up to #877, which added `head` frontmatter to the **Regression Testing** and **Black Box Testing** glossary pages to override their canonical tags to point at the corresponding Keploy blog posts instead of the docs pages. After that PR was merged and deployed, both pages still showed the self-referential docs canonical in `view-source` on production - the blog canonical never appeared.

### Issue - reference share prod: 

<img width="1881" height="450" alt="regression testing canonical tag issue" src="https://github.com/user-attachments/assets/6f575cb7-5b30-46d1-9581-c0c5c1ae2ea7" />


---


<img width="1901" height="365" alt="bbt canonical tag issue" src="https://github.com/user-attachments/assets/59c86bef-f952-4a97-aa7c-c3c47c0806b5" />

---

## Why It Wasn't Working

PR #877 added the correct frontmatter to both markdown files:

```yaml
head:
  - tag: link
    attrs:
      rel: canonical
      href: https://keploy.io/blog/community/regression-testing-an-introductory-guide
```

The data was there, parsed correctly, and exported by the MDX compiler - but Docusaurus 3.x never renders `frontMatter.head` for doc pages. Two things were happening:

1. **`DocFrontMatterSchema` has no `head` field.** The schema in `plugin-content-docs/lib/frontMatter.js` uses `.unknown()`, which silently accepts the key without error but nothing downstream ever reads it. The built-in `DocItem/Metadata` component only passes `title`, `description`, `keywords`, and `image` to the head -`frontMatter.head` is ignored entirely.

2. **`SiteMetadata` always wins.** `theme-classic/lib/theme/SiteMetadata/index.js` contains a `CanonicalUrlHeaders` component that unconditionally injects a self-referential `<link rel="canonical">` on every page based on the current URL. Since nothing was overriding it, this was the only canonical in the built HTML.

---

## The Fix

Added rendering of `frontMatter.head` inside the existing `<Head>` block in `src/theme/DocItem/index.js`:

```jsx
{Array.isArray(frontMatter.head) &&
  frontMatter.head.map((headTag, i) => {
    if (!headTag?.tag) return null;
    const {tag: tagName, attrs = {}} = headTag;
    return React.createElement(tagName, {key: i, ...attrs});
  })}
```

This works because `DocItem` renders deeper in the React component tree than `SiteMetadata`. React Helmet - which Docusaurus uses for SSG head management - keeps only the **last** `<link rel="canonical">` it encounters across all `<Head>` components. Since `DocItem` renders after `SiteMetadata`, its canonical replaces the self-referential docs one in the final static HTML.

---

## Testing

> **Important:** use `npm run serve` (static build), not `npm start` (dev server). The dev server is client-side only -canonical tags are invisible in `view-source` until JS hydrates, which is not how Google reads the page. Only the static build reflects what `view-source` on production sees.

**Build output check:**

```bash
npm run build

grep -o "canonical[^>]*>" build/concepts/reference/glossary/regression-testing/index.html
# → canonical" href="https://keploy.io/blog/community/regression-testing-an-introductory-guide">

grep -o "canonical[^>]*>" build/concepts/reference/glossary/black-box-testing/index.html
# → canonical" href="https://keploy.io/blog/community/black-box-testing-and-white-box-testing-a-complete-guide">
```

**Browser check (`npm run serve`):**

- `view-source:http://localhost:3000/docs/concepts/reference/glossary/regression-testing/` → blog canonical ✅
<img width="968" height="399" alt="Screenshot 2026-06-16 at 4 50 16 PM" src="https://github.com/user-attachments/assets/b7aec363-4a73-4664-95c9-abf4c41f96f0" />


- `view-source:http://localhost:3000/docs/concepts/reference/glossary/black-box-testing/` → blog canonical ✅
<img width="965" height="448" alt="Screenshot 2026-06-16 at 4 51 41 PM" src="https://github.com/user-attachments/assets/a8573ac6-20d2-4390-8005-4c11dcff4054" />


**Regression check - pages without `head` frontmatter are unaffected:**

```bash
grep -o "canonical[^>]*>" build/concepts/reference/glossary/unit-test-automation/index.html
# → canonical" href="https://keploy.io/docs/concepts/reference/glossary/unit-test-automation/">
```


---


---

## Sources & References


**Upstream Docusaurus references:**

- [`facebook/docusaurus` - `SiteMetadata` source](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/SiteMetadata/index.tsx) - confirms `CanonicalUrlHeaders` always runs
- [`facebook/docusaurus` - `DocItem/Metadata` source](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/Metadata/index.tsx) - confirms `head` frontmatter is never read for doc pages
- [`facebook/docusaurus` - `DocFrontMatter` schema](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-plugin-content-docs/src/frontMatter.ts) - no `head` field in the schema

**Related:**

- #877 - the PR that added `head` frontmatter to the markdown files (the change that was supposed to work but didn't)

