### PR TITLE
update: CI_CD Docs

### DIFF
--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -280,3 +280,53 @@ keploy cloud replay --app "<NAMESPACE>.<DEPLOYMENT>" --cluster "<CLUSTER>" --nam
 > `--delay` sets how long Keploy waits for the application to become ready before it sends requests. If it is shorter than the application's startup time, the tests can fail, so set it to comfortably cover the boot time.
 
 Hope this helps you out, if you still have any questions, reach out to us .
+
+---
+
+## Running cloud replay in CI
+
+Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
+
+### How authentication works
+
+The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
+
+- Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
+- In CI: add the key as a secret in your CI settings so the system injects it as an environment variable at runtime. Never hardcode it in your pipeline file.
+
+In GitHub Actions, secrets are stored under **Settings → Secrets and variables → Actions** and referenced in the pipeline as `${{ secrets.KEPLOY_API_KEY }}`.
+
+### Steps
+
+1. Add `KEPLOY_API_KEY` as a repository secret in GitHub (**Settings → Secrets and variables → Actions**).
+2. Install the Enterprise Keploy binary on the runner.
+3. Run `keploy cloud replay` with your application and cluster details.
+
+> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+
+### Example: GitHub Actions
+
+```yaml
+jobs:
+  keploy-cloud-replay:
+    runs-on: ubuntu-latest
+    env:
+      KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}
+    steps:
+      - name: Install Keploy Enterprise
+        run: |
+          curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
+          sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
+
+      - name: Cloud replay
+        run: |
+          keploy cloud replay \
+            --app "<NAMESPACE>.<DEPLOYMENT>" \
+            --cluster "<CLUSTER>" \
+            --namespace "<NAMESPACE>" \
+            --delay <DELAY>
+```
+
+Replace `<NAMESPACE>`, `<DEPLOYMENT>`, `<CLUSTER>`, and `<DELAY>` with your own values. Set `<DELAY>` to cover your application's startup time (in seconds).
+
+> `KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}` pulls the secret from GitHub's secret store and makes it available as a plain environment variable in all subsequent steps.

--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -221,7 +221,7 @@ _And... voila! You have successfully integrated keploy in GitHub CI pipeline �
 
 ## Running cloud replay in CI
 
-Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup, and on any CI control plane — GitHub Actions, GitLab CI, Jenkins, and others.
+Keploy cloud replay re-runs test sets that were recorded from a Kubernetes deployment. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup, and on any CI control plane — GitHub Actions, GitLab CI, Jenkins, and others.
 
 ### How authentication works
 

--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -221,92 +221,35 @@ _And... voila! You have successfully integrated keploy in GitHub CI pipeline �
 
 ## Running cloud replay in CI
 
-Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works the same way on any CI control plane — GitHub Actions, GitLab CI, Jenkins, and others — and with both Keploy Cloud and a self-hosted Keploy setup. The pipeline authenticates with an API key from an environment variable, so it needs no browser login.
-
-> Cloud replay uses the Enterprise Keploy binary, which the steps below install.
-
-The flow is the same on every CI system:
-
-1. Store your Keploy API key as a secret and expose it as the `KEPLOY_API_KEY` environment variable. The Keploy CLI reads this variable automatically.
-2. Install the Enterprise Keploy binary on the runner.
-3. Run `keploy cloud replay` with your application and cluster details.
-
-Because the replay command is plain CLI, it is identical across CI systems:
-
-```bash
-keploy cloud replay \
-  --app "<NAMESPACE>.<DEPLOYMENT>" \
-  --cluster "<CLUSTER>" \
-  --namespace "<NAMESPACE>" \
-  --delay <DELAY>
-```
-
-Replace `<NAMESPACE>`, `<DEPLOYMENT>`, and `<CLUSTER>` with your own values, and set `<DELAY>` to cover your application's startup time.
-
-### Example: GitHub Actions
-
-```yaml
-jobs:
-  keploy-cloud-replay:
-    runs-on: ubuntu-latest
-    env:
-      KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}
-    steps:
-      - name: Install Keploy
-        run: |
-          curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
-          sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
-
-      - name: Cloud replay
-        run: |
-          keploy cloud replay \
-            --app "<NAMESPACE>.<DEPLOYMENT>" \
-            --cluster "<CLUSTER>" \
-            --namespace "<NAMESPACE>" \
-            --delay <DELAY>
-```
-
-### Other CI systems
-
-The steps are identical elsewhere — expose `KEPLOY_API_KEY` from your secret store, install the binary, then run the command. For example, GitLab CI uses a masked CI/CD variable and Jenkins uses a credentials binding:
-
-```bash
-export KEPLOY_API_KEY="$KEPLOY_API_KEY" # injected from your CI secret store
-curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
-sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
-keploy cloud replay --app "<NAMESPACE>.<DEPLOYMENT>" --cluster "<CLUSTER>" --namespace "<NAMESPACE>" --delay <DELAY>
-```
-
-> `--delay` sets how long Keploy waits for the application to become ready before it sends requests. If it is shorter than the application's startup time, the tests can fail, so set it to comfortably cover the boot time.
-
-Hope this helps you out, if you still have any questions, reach out to us .
-
----
-
-## Running cloud replay in CI
-
-Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
+Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup, and on any CI control plane — GitHub Actions, GitLab CI, Jenkins, and others.
 
 ### How authentication works
 
-The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
+The CLI reads the `KEPLOY_API_KEY` environment variable automatically — no browser login needed.
 
-- Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
-- In CI: add the key as a secret in your CI settings so the system injects it as an environment variable at runtime. Never hard-code it in your pipeline file.
+- **Locally:** `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
+- **In CI:** store the key as a secret in your CI system so it gets injected as an environment variable at runtime. Never hard-code it in your pipeline file.
 
-In GitHub Actions, secrets are stored under **Settings → Secrets and variables → Actions** and referenced in the pipeline as `${{ secrets.KEPLOY_API_KEY }}`.
+> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
 
 ### Steps
 
-1. Add `KEPLOY_API_KEY` as a repository secret in GitHub (**Settings → Secrets and variables → Actions**).
-2. Install the Enterprise Keploy binary on the runner.
-3. Run `keploy cloud replay` with your application and cluster details.
-
-> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+1. **Store the API key** — add `KEPLOY_API_KEY` as a secret in your CI system.
+   - GitHub Actions: go to **Settings → Secrets and variables → Actions → New repository secret**, name it `KEPLOY_API_KEY`.
+   - GitLab CI: go to **Settings → CI/CD → Variables**, add it as a masked variable.
+   - Jenkins: add a **Secret text** credential via **Manage Jenkins → Credentials**.
+2. **Install** the Enterprise Keploy binary on the runner.
+3. **Run** `keploy cloud replay` with your application and cluster details.
 
 ### Example: GitHub Actions
 
 ```yaml
+name: Keploy Cloud Replay
+
+on:
+  push:
+    branches: [main]
+
 jobs:
   keploy-cloud-replay:
     runs-on: ubuntu-latest
@@ -327,6 +270,8 @@ jobs:
             --delay <DELAY>
 ```
 
-Replace `<NAMESPACE>`, `<DEPLOYMENT>`, `<CLUSTER>`, and `<DELAY>` with your own values. Set `<DELAY>` to cover your application's startup time (in seconds).
+Replace `<NAMESPACE>`, `<DEPLOYMENT>`, `<CLUSTER>`, and `<DELAY>` with your own values. Set `<DELAY>` (in seconds) to comfortably cover your application's startup time.
 
-> `KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}` pulls the secret from GitHub's secret store and makes it available as a plain environment variable in all subsequent steps.
+> `KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}` pulls the value from GitHub's secret store and makes it available as an environment variable in all subsequent steps.
+
+Hope this helps you out, if you still have any questions, reach out to us .

--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -23,6 +23,8 @@ Keploy can be integrated with GitHub by two methods:-
 1. [Using Shell Scripts](#shell-scripts)
 2. [Using GitHub Actions](#github-actions)
 
+If you run a self-hosted Keploy cluster, you can also [run Cloud Replay from CI](#cloud-replay-self-hosted-in-github-actions).
+
 ## Shell Scripts
 
 GitHub scripts are the easiest way to integrate Keploy with GitHub. We will be using [express-mongoose](https://github.com/keploy/samples-typescript/tree/main/express-mongoose) sample-application for the example. You can either add the following script to yout `github workflow` or create a new worflow `.github/workflows/keploy-test.yml`:-
@@ -214,5 +216,51 @@ sudo -E keploy test -c node src/app.js --delay 10 --path ./
 ```
 
 _And... voila! You have successfully integrated keploy in GitHub CI pipeline 🌟_
+
+---
+
+## Cloud Replay (Self-Hosted) in GitHub Actions
+
+If you run a self-hosted Keploy cluster, you can replay your recorded test sets against the cluster directly from CI — with no browser login. CI authenticates using an **API key**, and the replay runs **inside your cluster**.
+
+> Cloud Replay is an **Enterprise** feature and uses the Enterprise Keploy binary (installed in the workflow below), not the open-source binary.
+
+```bash
+export KEPLOY_API_KEY="<API_KEY>"
+```
+
+The Keploy CLI reads `KEPLOY_API_KEY` from the environment automatically, so no `keploy login` or browser step is needed in CI.
+
+### 2. Add the workflow
+
+Create `.github/workflows/keploy-cloud-replay.yml`:
+
+```yaml
+jobs:
+  keploy-cloud-replay:
+    runs-on: ubuntu-latest
+    env:
+      KEPLOY_API_KEY: ${{ KEPLOY_API_KEY }}
+    steps:
+      - name: Install Keploy (Enterprise)
+        run: |
+          curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
+          sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
+
+      - name: Cloud Replay (in-cluster)
+        run: |
+          keploy cloud replay \
+            --app "<NAMESPACE>.<DEPLOYMENT>" \
+            --cluster "<CLUSTER>" \
+            --namespace "<NAMESPACE>" \
+            --delay <DELAY>
+```
+
+Replace `<NAMESPACE>`, `<DEPLOYMENT>`, and `<CLUSTER>` with your own values, and set `<DELAY>` to cover your application's startup time.
+
+> - `--delay` is how long Keploy waits for the app to become ready before sending requests. If it is shorter than the app's cold-start time, the tests can all fail.
+> - The CI runner must be able to reach your cluster's ingress URL.
+
+The step passes when the replay summary reports `Failed 0`.
 
 Hope this helps you out, if you still have any questions, reach out to us .

--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -23,11 +23,11 @@ Keploy can be integrated with GitHub by two methods:-
 1. [Using Shell Scripts](#shell-scripts)
 2. [Using GitHub Actions](#github-actions)
 
-If you run a self-hosted Keploy cluster, you can also [run Cloud Replay from CI](#cloud-replay-self-hosted-in-github-actions).
+You can also [run cloud replay from your CI pipeline](#running-cloud-replay-in-ci).
 
 ## Shell Scripts
 
-GitHub scripts are the easiest way to integrate Keploy with GitHub. We will be using [express-mongoose](https://github.com/keploy/samples-typescript/tree/main/express-mongoose) sample-application for the example. You can either add the following script to yout `github workflow` or create a new worflow `.github/workflows/keploy-test.yml`:-
+GitHub scripts are the easiest way to integrate Keploy with GitHub. We will be using [express-mongoose](https://github.com/keploy/samples-typescript/tree/main/express-mongoose) sample-application for the example. You can either add the following script to your `github workflow` or create a new workflow `.github/workflows/keploy-test.yml`:-
 
 ```yaml
 - name: Checkout Commit
@@ -219,35 +219,45 @@ _And... voila! You have successfully integrated keploy in GitHub CI pipeline �
 
 ---
 
-## Cloud Replay (Self-Hosted) in GitHub Actions
+## Running cloud replay in CI
 
-If you run a self-hosted Keploy cluster, you can replay your recorded test sets against the cluster directly from CI — with no browser login. CI authenticates using an **API key**, and the replay runs **inside your cluster**.
+Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works the same way on any CI control plane — GitHub Actions, GitLab CI, Jenkins, and others — and with both Keploy Cloud and a self-hosted Keploy setup. The pipeline authenticates with an API key from an environment variable, so it needs no browser login.
 
-> Cloud Replay is an **Enterprise** feature and uses the Enterprise Keploy binary (installed in the workflow below), not the open-source binary.
+> Cloud replay uses the Enterprise Keploy binary, which the steps below install.
+
+The flow is the same on every CI system:
+
+1. Store your Keploy API key as a secret and expose it as the `KEPLOY_API_KEY` environment variable. The Keploy CLI reads this variable automatically.
+2. Install the Enterprise Keploy binary on the runner.
+3. Run `keploy cloud replay` with your application and cluster details.
+
+Because the replay command is plain CLI, it is identical across CI systems:
 
 ```bash
-export KEPLOY_API_KEY="<API_KEY>"
+keploy cloud replay \
+  --app "<NAMESPACE>.<DEPLOYMENT>" \
+  --cluster "<CLUSTER>" \
+  --namespace "<NAMESPACE>" \
+  --delay <DELAY>
 ```
 
-The Keploy CLI reads `KEPLOY_API_KEY` from the environment automatically, so no `keploy login` or browser step is needed in CI.
+Replace `<NAMESPACE>`, `<DEPLOYMENT>`, and `<CLUSTER>` with your own values, and set `<DELAY>` to cover your application's startup time.
 
-### 2. Add the workflow
-
-Create `.github/workflows/keploy-cloud-replay.yml`:
+### Example: GitHub Actions
 
 ```yaml
 jobs:
   keploy-cloud-replay:
     runs-on: ubuntu-latest
     env:
-      KEPLOY_API_KEY: ${{ KEPLOY_API_KEY }}
+      KEPLOY_API_KEY: ${{ secrets.KEPLOY_API_KEY }}
     steps:
-      - name: Install Keploy (Enterprise)
+      - name: Install Keploy
         run: |
           curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
           sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
 
-      - name: Cloud Replay (in-cluster)
+      - name: Cloud replay
         run: |
           keploy cloud replay \
             --app "<NAMESPACE>.<DEPLOYMENT>" \
@@ -256,11 +266,17 @@ jobs:
             --delay <DELAY>
 ```
 
-Replace `<NAMESPACE>`, `<DEPLOYMENT>`, and `<CLUSTER>` with your own values, and set `<DELAY>` to cover your application's startup time.
+### Other CI systems
 
-> - `--delay` is how long Keploy waits for the app to become ready before sending requests. If it is shorter than the app's cold-start time, the tests can all fail.
-> - The CI runner must be able to reach your cluster's ingress URL.
+The steps are identical elsewhere — expose `KEPLOY_API_KEY` from your secret store, install the binary, then run the command. For example, GitLab CI uses a masked CI/CD variable and Jenkins uses a credentials binding:
 
-The step passes when the replay summary reports `Failed 0`.
+```bash
+export KEPLOY_API_KEY="$KEPLOY_API_KEY" # injected from your CI secret store
+curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
+sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
+keploy cloud replay --app "<NAMESPACE>.<DEPLOYMENT>" --cluster "<CLUSTER>" --namespace "<NAMESPACE>" --delay <DELAY>
+```
+
+> `--delay` sets how long Keploy waits for the application to become ready before it sends requests. If it is shorter than the application's startup time, the tests can fail, so set it to comfortably cover the boot time.
 
 Hope this helps you out, if you still have any questions, reach out to us .

--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -292,7 +292,7 @@ Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works
 The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
 
 - Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
-- In CI: add the key as a secret in your CI settings so the system injects it as an environment variable at runtime. Never hardcode it in your pipeline file.
+- In CI: add the key as a secret in your CI settings so the system injects it as an environment variable at runtime. Never hard-code it in your pipeline file.
 
 In GitHub Actions, secrets are stored under **Settings → Secrets and variables → Actions** and referenced in the pipeline as `${{ secrets.KEPLOY_API_KEY }}`.
 

--- a/versioned_docs/version-4.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-4.0.0/ci-cd/gitlab.md
@@ -158,7 +158,7 @@ Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works
 The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
 
 - Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
-- In CI: add the key as a masked CI/CD variable so the system injects it as an environment variable at runtime. Never hardcode it in your pipeline file.
+- In CI: add the key as a masked CI/CD variable so the system injects it as an environment variable at runtime. Never hard-code it in your pipeline file.
 
 In GitLab CI, go to **Settings → CI/CD → Variables**, add `KEPLOY_API_KEY` as a masked variable, and it is automatically available in all pipeline jobs as `$KEPLOY_API_KEY`.
 

--- a/versioned_docs/version-4.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-4.0.0/ci-cd/gitlab.md
@@ -151,7 +151,7 @@ Hope this helps you out, if you still have any questions, reach out to us .
 
 ## Running cloud replay in CI
 
-Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
+Keploy cloud replay re-runs test sets that were recorded from a Kubernetes deployment. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
 
 ### How authentication works
 

--- a/versioned_docs/version-4.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-4.0.0/ci-cd/gitlab.md
@@ -146,3 +146,48 @@ Integrating Keploy with GitLab CI automates the testing process, ensuring that t
 If you’re thinking, “This pipeline looks cool, but I need the _whole thing_ to integrate with your application!” — well, you're in luck! Check it out [here](https://github.com/keploy/samples-python) and get ready to copy-paste your way to success! ✨🚀
 
 Hope this helps you out, if you still have any questions, reach out to us .
+
+---
+
+## Running cloud replay in CI
+
+Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
+
+### How authentication works
+
+The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
+
+- Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
+- In CI: add the key as a masked CI/CD variable so the system injects it as an environment variable at runtime. Never hardcode it in your pipeline file.
+
+In GitLab CI, go to **Settings → CI/CD → Variables**, add `KEPLOY_API_KEY` as a masked variable, and it is automatically available in all pipeline jobs as `$KEPLOY_API_KEY`.
+
+### Steps
+
+1. Add `KEPLOY_API_KEY` as a masked CI/CD variable (**Settings → CI/CD → Variables**).
+2. Install the Enterprise Keploy binary on the runner.
+3. Run `keploy cloud replay` with your application and cluster details.
+
+> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+
+### Example: GitLab CI
+
+```yaml
+keploy-cloud-replay:
+  stage: test
+  image: ubuntu:22.04
+  # KEPLOY_API_KEY is injected automatically from the masked CI/CD variable
+  script:
+    - apt-get update -qq && apt-get install -y -qq curl sudo
+    - curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
+    - chmod +x /tmp/keploy && mv /tmp/keploy /usr/local/bin/keploy
+    - keploy cloud replay
+      --app "<NAMESPACE>.<DEPLOYMENT>"
+      --cluster "<CLUSTER>"
+      --namespace "<NAMESPACE>"
+      --delay <DELAY>
+```
+
+Replace `<NAMESPACE>`, `<DEPLOYMENT>`, `<CLUSTER>`, and `<DELAY>` with your own values. Set `<DELAY>` to cover your application's startup time (in seconds).
+
+> Because `KEPLOY_API_KEY` is defined as a masked variable in GitLab, it is already present in the job's environment — no `export` step is needed.

--- a/versioned_docs/version-4.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-4.0.0/ci-cd/gitlab.md
@@ -181,11 +181,12 @@ keploy-cloud-replay:
     - apt-get update -qq && apt-get install -y -qq curl sudo
     - curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
     - chmod +x /tmp/keploy && mv /tmp/keploy /usr/local/bin/keploy
-    - keploy cloud replay
-      --app "<NAMESPACE>.<DEPLOYMENT>"
-      --cluster "<CLUSTER>"
-      --namespace "<NAMESPACE>"
-      --delay <DELAY>
+    - |
+      keploy cloud replay \
+        --app "<NAMESPACE>.<DEPLOYMENT>" \
+        --cluster "<CLUSTER>" \
+        --namespace "<NAMESPACE>" \
+        --delay <DELAY>
 ```
 
 Replace `<NAMESPACE>`, `<DEPLOYMENT>`, `<CLUSTER>`, and `<DELAY>` with your own values. Set `<DELAY>` to cover your application's startup time (in seconds).

--- a/versioned_docs/version-4.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-4.0.0/ci-cd/jenkins.md
@@ -176,7 +176,7 @@ Hope this helps you out, if you still have any questions, reach out to us .
 
 ## Running cloud replay in CI
 
-Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
+Keploy cloud replay re-runs test sets that were recorded from a Kubernetes deployment. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
 
 ### How authentication works
 

--- a/versioned_docs/version-4.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-4.0.0/ci-cd/jenkins.md
@@ -183,7 +183,7 @@ Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works
 The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
 
 - Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
-- In CI: add the key to Jenkins' credentials store so the system injects it as an environment variable at runtime. Never hardcode it in your Jenkinsfile.
+- In CI: add the key to Jenkins' credentials store so the system injects it as an environment variable at runtime. Never hard-code it in your Jenkins pipeline file.
 
 In Jenkins, go to **Manage Jenkins → Credentials**, add a **Secret text** credential with ID `keploy-api-key`, and use `withCredentials` in your pipeline to bind it to `KEPLOY_API_KEY`.
 

--- a/versioned_docs/version-4.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-4.0.0/ci-cd/jenkins.md
@@ -171,3 +171,61 @@ Testrun passed for testcase with id: "test-2"
 _And... voila! You have successfully integrated keploy in Jenkins CI/CD pipeline 🌟_
 
 Hope this helps you out, if you still have any questions, reach out to us .
+
+---
+
+## Running cloud replay in CI
+
+Keploy cloud replay re-runs your recorded test sets from a CI pipeline. It works with both **Keploy Cloud** and a **self-hosted Keploy** setup — the command is the same either way.
+
+### How authentication works
+
+The CLI reads the `KEPLOY_API_KEY` environment variable automatically. You do not need to pass it as a flag or log in through a browser.
+
+- Locally: `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
+- In CI: add the key to Jenkins' credentials store so the system injects it as an environment variable at runtime. Never hardcode it in your Jenkinsfile.
+
+In Jenkins, go to **Manage Jenkins → Credentials**, add a **Secret text** credential with ID `keploy-api-key`, and use `withCredentials` in your pipeline to bind it to `KEPLOY_API_KEY`.
+
+### Steps
+
+1. Add `KEPLOY_API_KEY` as a **Secret text** credential in Jenkins (**Manage Jenkins → Credentials**).
+2. Install the Enterprise Keploy binary on the agent.
+3. Run `keploy cloud replay` with your application and cluster details.
+
+> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+
+### Example: Jenkins Declarative Pipeline
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Install Keploy Enterprise') {
+            steps {
+                sh '''
+                curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
+                sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
+                '''
+            }
+        }
+        stage('Cloud replay') {
+            steps {
+                withCredentials([string(credentialsId: 'keploy-api-key', variable: 'KEPLOY_API_KEY')]) {
+                    sh '''
+                    keploy cloud replay \
+                      --app "<NAMESPACE>.<DEPLOYMENT>" \
+                      --cluster "<CLUSTER>" \
+                      --namespace "<NAMESPACE>" \
+                      --delay <DELAY>
+                    '''
+                }
+            }
+        }
+    }
+}
+```
+
+Replace `<NAMESPACE>`, `<DEPLOYMENT>`, `<CLUSTER>`, and `<DELAY>` with your own values. Set `<DELAY>` to cover your application's startup time (in seconds).
+
+> `withCredentials` binds the Jenkins secret to `KEPLOY_API_KEY` only for the duration of that stage — the CLI picks it up automatically.


### PR DESCRIPTION
## Summary

Adds a **Running cloud replay in CI** section to all three CI/CD docs (GitHub, GitLab, Jenkins).

- Cloud replay re-runs **test sets recorded from a Kubernetes deployment** — this is now explicitly called out in each file
- Works with both Keploy Cloud and self-hosted Keploy
- Generic across CI systems: GitHub Actions, GitLab CI, and Jenkins examples included
- Each file has a system-specific, copy-pasteable pipeline snippet

## Changes

- `github.md` — new section with complete GitHub Actions workflow (name, on, jobs) and secrets.KEPLOY_API_KEY
- `gitlab.md` — new section with GitLab CI masked variable example, shell continuation with `|` and `\`
- `jenkins.md` — new section with Jenkins withCredentials example

## Test plan

- [x] Prettier passes on all three files
- [x] Vale spell check passes
- [x] commitlint passes (all commits use valid Conventional Commits types)
- [x] DCO signed off
- [x] Addressed all review comments from amaan-bhati: secrets context fixed, duplicate section removed, full YAML added, GitLab multi-line command style fixed, k8s-recorded tests clarification added
