### PR TITLE
docs(ci-cd): use enterprise install script for cloud replay

### DIFF
--- a/versioned_docs/version-4.0.0/ci-cd/github.md
+++ b/versioned_docs/version-4.0.0/ci-cd/github.md
@@ -230,7 +230,7 @@ The CLI reads the `KEPLOY_API_KEY` environment variable automatically — no bro
 - **Locally:** `export KEPLOY_API_KEY="<your-api-key>"` before running the command.
 - **In CI:** store the key as a secret in your CI system so it gets injected as an environment variable at runtime. Never hard-code it in your pipeline file.
 
-> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+> Cloud replay requires the Enterprise binary. Install it with `curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh` — not the open-source `keploy.io/install.sh`.
 
 ### Steps
 
@@ -258,8 +258,7 @@ jobs:
     steps:
       - name: Install Keploy Enterprise
         run: |
-          curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
-          sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
+          curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
 
       - name: Cloud replay
         run: |

--- a/versioned_docs/version-4.0.0/ci-cd/gitlab.md
+++ b/versioned_docs/version-4.0.0/ci-cd/gitlab.md
@@ -168,7 +168,7 @@ In GitLab CI, go to **Settings → CI/CD → Variables**, add `KEPLOY_API_KEY` a
 2. Install the Enterprise Keploy binary on the runner.
 3. Run `keploy cloud replay` with your application and cluster details.
 
-> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+> Cloud replay requires the Enterprise binary. Install it with `curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh` — not the open-source `keploy.io/install.sh`.
 
 ### Example: GitLab CI
 
@@ -179,8 +179,7 @@ keploy-cloud-replay:
   # KEPLOY_API_KEY is injected automatically from the masked CI/CD variable
   script:
     - apt-get update -qq && apt-get install -y -qq curl sudo
-    - curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
-    - chmod +x /tmp/keploy && mv /tmp/keploy /usr/local/bin/keploy
+    - curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
     - |
       keploy cloud replay \
         --app "<NAMESPACE>.<DEPLOYMENT>" \

--- a/versioned_docs/version-4.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-4.0.0/ci-cd/jenkins.md
@@ -193,7 +193,7 @@ In Jenkins, go to **Manage Jenkins → Credentials**, add a **Secret text** cred
 2. Install the Enterprise Keploy binary on the agent.
 3. Run `keploy cloud replay` with your application and cluster details.
 
-> Cloud replay requires the Enterprise binary (`keploy.io/ent/dl/latest/enterprise_linux_amd64`), not the open-source one.
+> Cloud replay requires the Enterprise binary. Install it with `curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh` — not the open-source `keploy.io/install.sh`.
 
 ### Example: Jenkins Declarative Pipeline
 
@@ -204,8 +204,7 @@ pipeline {
         stage('Install Keploy Enterprise') {
             steps {
                 sh '''
-                curl --silent --location "https://keploy.io/ent/dl/latest/enterprise_linux_amd64" -o /tmp/keploy
-                sudo chmod +x /tmp/keploy && sudo mv /tmp/keploy /usr/local/bin/keploy
+                curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
                 '''
             }
         }


### PR DESCRIPTION
Replace the manual binary download (curl+chmod+mv) with the enterprise install script across all three CI/CD docs (github.md, gitlab.md, jenkins.md). Also updates the callout note in each file to reference the install script URL.