### PR TITLE
fix(ci-cd): use POSIX dot operator instead of source in Jenkins snippet

### DIFF
--- a/versioned_docs/version-4.0.0/ci-cd/jenkins.md
+++ b/versioned_docs/version-4.0.0/ci-cd/jenkins.md
@@ -204,7 +204,7 @@ pipeline {
         stage('Install Keploy Enterprise') {
             steps {
                 sh '''
-                curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
+                curl --silent -O -L https://keploy.io/ent/install.sh && . install.sh
                 '''
             }
         }


### PR DESCRIPTION
The Jenkins sh block runs under /bin/sh (dash on Ubuntu), which does not have source. This causes source install.sh to fail with source: not found.

Fix: replace source with . (the POSIX dot operator), which is equivalent and works in both sh and bash.

Only jenkins.md is affected — GitHub Actions and GitLab CI both default to bash where source works fine.