### PR TITLE
feat: add Meta Pixel to docs site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -568,6 +568,7 @@ fbq('track', 'PageView');`,
     ],
   ],
 
+  clientModules: [require.resolve("./src/metaPixelRouteTracker.js")],
   scripts: [
     {
       src: "/docs/scripts/feedback.js",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -173,7 +173,7 @@ fbq('track', 'PageView');`,
     {
       tagName: "noscript",
       attributes: {},
-      innerHTML: `<img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=2006330080011702&ev=PageView&noscript=1" />`,
+      innerHTML: `<img height="1" width="1" style="display:none" alt="" src="https://www.facebook.com/tr?id=2006330080011702&ev=PageView&noscript=1" />`,
     },
     // End Meta Pixel Code
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -155,6 +155,25 @@ module.exports = {
         },
       }),
     },
+    // Meta Pixel Code
+    {
+      tagName: "script",
+      innerHTML: `!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('init', '2006330080011702');
+fbq('track', 'PageView');`,
+    },
+    {
+      tagName: "noscript",
+      innerHTML: `<img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=2006330080011702&ev=PageView&noscript=1" />`,
+    },
+    // End Meta Pixel Code
   ],
   title: "Keploy Documentation",
   titleDelimiter: "🐰",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -158,6 +158,7 @@ module.exports = {
     // Meta Pixel Code
     {
       tagName: "script",
+      attributes: {},
       innerHTML: `!function(f,b,e,v,n,t,s)
 {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 n.callMethod.apply(n,arguments):n.queue.push(arguments)};
@@ -171,6 +172,7 @@ fbq('track', 'PageView');`,
     },
     {
       tagName: "noscript",
+      attributes: {},
       innerHTML: `<img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=2006330080011702&ev=PageView&noscript=1" />`,
     },
     // End Meta Pixel Code

--- a/src/metaPixelRouteTracker.js
+++ b/src/metaPixelRouteTracker.js
@@ -4,7 +4,7 @@
 // explicitly here.
 export function onRouteDidUpdate({location, previousLocation}) {
   if (previousLocation && location.pathname !== previousLocation.pathname) {
-    if (typeof window !== "undefined" && typeof window.fbq === "function") {
+    if (typeof window.fbq === "function") {
       window.fbq("track", "PageView");
     }
   }

--- a/src/metaPixelRouteTracker.js
+++ b/src/metaPixelRouteTracker.js
@@ -1,0 +1,11 @@
+// Re-fire Meta Pixel PageView on client-side route changes.
+// The base snippet in docusaurus.config.js (headTags) only fires PageView on
+// the initial load; Docusaurus is an SPA, so in-app navigation must be tracked
+// explicitly here.
+export function onRouteDidUpdate({location, previousLocation}) {
+  if (previousLocation && location.pathname !== previousLocation.pathname) {
+    if (typeof window !== "undefined" && typeof window.fbq === "function") {
+      window.fbq("track", "PageView");
+    }
+  }
+}


### PR DESCRIPTION
## What

Installs the Meta (Facebook) Pixel (`2006330080011702`) site-wide on the docs.

- **Base snippet** injected into `<head>` on every page via `headTags` (`docusaurus.config.js`): loads `fbevents.js`, runs `fbq('init', ...)`, and fires the initial `PageView`. `fbq` is defined synchronously by the snippet, so the first `PageView` can never race the loader.
- **SPA route tracking** (`src/metaPixelRouteTracker.js`, registered as a `clientModule`): re-fires `PageView` on client-side navigation via Docusaurus's `onRouteDidUpdate` lifecycle hook. Docusaurus is a single-page app, so without this the base snippet would only ever report the first page a visitor lands on.
- Includes the `<noscript>` tracking-pixel fallback for JS-disabled clients.

## Events tracked

- **`PageView`** only.
- No other events (`ViewContent`, `Lead`, `CompleteRegistration`, custom, etc.) are tracked in this PR. Those can be added later on specific CTAs/flows.

## When does the event fire?

The **first** PageView is fired synchronously by the base script (where `fbq` is guaranteed defined), and **subsequent** PageViews are fired by the client module on route changes. This split avoids both an fbq-not-ready race on the first load and double-counting the initial page.

| User action | What happens | PageView fired? |
| --- | --- | --- |
| Lands on the site / full reload | `<head>` snippet runs `fbq('init')` + `fbq('track','PageView')` | ✅ 1 (base script) |
| `onRouteDidUpdate` runs on first render | `previousLocation` is `null` → guard skips it | ⏭️ skipped (avoids double-count) |
| Clicks an internal link (SPA nav) | `location.pathname` differs from `previousLocation.pathname` → fires `fbq('track','PageView')` | ✅ 1 per navigation |
| Navigation where only the query/hash changes (same path) | pathname unchanged → guard skips | ❌ none |
| Ad blocker / tracking protection on, or JS disabled | `fbevents.js` blocked (the `<noscript>` `<img>` covers the JS-off case with a single beacon) | ⚠️ browser pixel dropped |

## How the pixel leads to an ad (flow)

```mermaid
flowchart TD
    A[User opens keploy.io/docs] --> B[Meta Pixel runs on page load<br/>fbq init + PageView]
    B --> C[Browser sends beacon to Meta<br/>facebook.com/tr + Facebook cookies]
    C --> D[Meta identifies the visitor via cookie<br/>Facebook account XYZ]
    D --> E[Meta adds the user to Keploy's audience]
    E --> F[Later the user scrolls Instagram / Facebook]
    F --> G[Meta serves the user a Keploy ad]
```

The site never sends personal data — it only says "a PageView happened." **Identity is matched on Meta's side via the Facebook cookies the browser attaches to the `/tr` request.** This depends on third-party cookies, so it's weaker/absent for logged-out users, Safari/Firefox, private mode, and ad blockers (a future Conversions API would recover some of that).

## How to test (for reviewers)

> **Important:** disable ad blockers / tracking protection first, or test in an Incognito window with the ad blocker set to *not* run in Incognito. Blockers drop `fbevents.js` (shows as `blocked:other`) and you'll see zero events even though the code is correct.

1. Install the [Meta Pixel Helper](https://chromewebstore.google.com/detail/meta-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc) Chrome extension.
2. Run the docs locally: `yarn start`, then open `http://localhost:3000/docs/`.
3. Open DevTools → **Network** tab, check **"Preserve log"**, and type `facebook` in the filter bar.
4. **Reload the page.** Expected:
   - `fbevents.js` → `200` (not `blocked:other` / 0 kB)
   - `tr/?id=2006330080011702&ev=PageView` → `200`
   - Meta Pixel Helper shows the pixel **Active** with **1 PageView**.
5. **Click an internal link** (SPA navigation, no full reload). Expected:
   - a **new** `tr/?...ev=PageView` beacon appears → PageView count goes **1 → 2**.
6. **Click a link to a same-path URL (query/hash only).** Expected: **no** new beacon (pathname-guarded).
7. *(Optional, end-to-end)* In **Meta Events Manager → Test Events**, enter pixel `2006330080011702` and browse the local site to watch the same PageViews land on Meta's side.

**Pass criteria:** 1 PageView on load, +1 per SPA path change, 0 on same-path clicks — all beacons `200`.

## Verify (author)

- Ran a full `yarn build` locally; compiles clean and the generated static HTML contains the pixel (`fbq("init","2006330080011702"),fbq("track","PageView")`, the `connect.facebook.net/en_US/fbevents.js` loader, and the `<noscript>` beacon).
- `onRouteDidUpdate` guard reviewed: fires only on an actual `pathname` change, skips the initial load (`previousLocation === null`) and same-path updates — so no double-count on landing and one PageView per SPA navigation.
- No CSP changes needed for docs (no enforcing Content-Security-Policy blocks Facebook's domains here); this PR touches only `docusaurus.config.js` and `src/metaPixelRouteTracker.js`.

## Note on the hardcoded pixel ID

The pixel ID is inlined, matching every other tracker in this repo — Microsoft Clarity (`static/scripts/clarity.js`), Apollo (`apollo-init.js`), and Google Analytics/gtag (`docusaurus.config.js`) are all hardcoded, and the repo has no `.env` files or `process.env` usage to read from. The preview/staging-pollution concern is valid but applies equally to those existing trackers, so moving all of them behind env config (with preview/staging skipped) is proposed as a dedicated repo-wide follow-up rather than gating the pixel alone here.

Docs deploys separately from the landing page ([keploy/landing#245](https://github.com/keploy/landing/pull/245) adds the same snippet there) — this PR gives the docs site the equivalent coverage.


