### PR TITLE
fix(navbar): remove conflicting docsearch deps and CSS overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@docsearch/core": "^4.5.0",
-    "@docsearch/react": "^4.5.0",
     "@docusaurus/core": "3.9.2",
     "@docusaurus/plugin-sitemap": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -531,9 +531,6 @@ html[data-theme="dark"] .navbar {
 
 /* Search */
 
-.DocSearch-Button {
-  @apply rounded-lg px-3 py-2 !important;
-}
 
 .button.button--secondary.button--outline:not(.button--active):not(:hover) {
   color: #ffffff;
@@ -556,10 +553,6 @@ footer svg {
 @media (max-width: 996px) {
   .footer .footer__separators {
     display: none;
-  }
-
-  .DocSearch-Button {
-    @apply mr-2 !important;
   }
 
   /* .footer .footer__block {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,7 +1638,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@docsearch/core@4.6.2", "@docsearch/core@^4.5.0":
+"@docsearch/core@4.6.2":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@docsearch/core/-/core-4.6.2.tgz#0a6fdc13b1eb12153cb19316f911479b67f7bd58"
   integrity sha512-/S0e6Dj7Zcm8m9Rru49YEX49dhU11be68c+S/BCyN8zQsTTgkKzXlhRbVL5mV6lOLC2+ZRRryaTdcm070Ug2oA==
@@ -1648,7 +1648,7 @@
   resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-4.6.2.tgz#986776619dccbf798176c75e858cc22f5e710bb4"
   integrity sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==
 
-"@docsearch/react@^3.9.0 || ^4.1.0", "@docsearch/react@^4.5.0":
+"@docsearch/react@^3.9.0 || ^4.1.0":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-4.6.2.tgz#e6c65fb87fb943eefaa936debe6d31bb51b25056"
   integrity sha512-/BbtGFtqVOGwZx0dw/UfhN/0/DmMQYnulY4iv0tPRhC2JCXv0ka/+izwt3Jzo1ZxXS/2eMvv9zHsBJOK1I9f/w==


### PR DESCRIPTION
What has changed?
Issue: The navbar search box was not styled correctly, unlike the default clean look on stock Docusaurus sites.
<img width="1439" height="854" alt="image" src="https://github.com/user-attachments/assets/866db697-f589-4d5d-8f7e-cbd5854e5db7" />


Cause:
@docsearch/react/@docsearch/core were unnecessarily added directly in package.json, conflicting with the version already bundled by @docusaurus/preset-classic.
Custom !important CSS overrides on .DocSearch-Button in src/css/custom.css were fighting DocSearch's default styling.
Fix: Removed both, restoring the default clean search box look.

Fixes https://github.com/keploy/enterprise/issues/2291

Image after fix
<img width="1439" height="849" alt="image" src="https://github.com/user-attachments/assets/7f045cb5-cf5f-497d-9a20-b4fbd88f4f9e" />
