### PR TITLE
docs: document automatic MySQL port detection

### DIFF
--- a/versioned_docs/version-4.0.0/keploy-explained/common-errors.md
+++ b/versioned_docs/version-4.0.0/keploy-explained/common-errors.md
@@ -194,6 +194,36 @@ Keploy does not support the protocol or API structure you are using (e.g., gRPC,
 - Confirm the supported protocols (currently HTTP/REST and GraphQL).
 - Consider alternative tools or frameworks for unsupported protocols.
 
+### 12. MySQL connection hangs during the handshake
+
+#### Description:
+
+Your application cannot reach MySQL while Keploy is running. The client reports a lost connection during the handshake, and the application often never finishes starting because its connection pool is stuck:
+
+```
+ERROR 2013 (HY000): Lost connection to server at 'handshake: reading initial communication packet'
+```
+
+The same setup connects normally when you run it without Keploy.
+
+#### Possible Cause:
+
+- `disableMysqlAutoDetect` is set to `true`, and the port your database listens on is not listed in `mysqlPorts`.
+- You are running a Keploy version that predates automatic MySQL port detection, which recognised only `3306` and `4000` unless you configured `mysqlPorts`.
+
+#### Solution:
+
+- Remove `disableMysqlAutoDetect` from your config file, or set it to `false`. Keploy then identifies MySQL on any port on its own.
+- If you need detection off, list every MySQL port your application uses:
+
+  ```yaml
+  mysqlPorts: [3307, 6033]
+  ```
+
+- On an older Keploy version, upgrade, or add the port to `mysqlPorts`.
+
+See [MySQL port detection](../running-keploy/configuration-file.md#mysql-port-detection) for how Keploy identifies the protocol during Record and recovers the port during Test.
+
 If you’re still encountering issues after trying these solutions, feel free to reach out to the Keploy team on [Slack](https://keploy.io/slack).
 
 Happy Testing!

--- a/versioned_docs/version-4.0.0/running-keploy/configuration-file.md
+++ b/versioned_docs/version-4.0.0/running-keploy/configuration-file.md
@@ -74,6 +74,8 @@ record:
   filters: []
 configPath: ""
 bypassRules: []
+mysqlPorts: []
+disableMysqlAutoDetect: false
 cmdType: "native"
 enableTesting: false
 keployContainer: "keploy-v3"
@@ -163,6 +165,40 @@ The `record` section in the Keploy-config file allows you to define parameters f
         host: ""
         port: 0
   ```
+
+- **`mysqlPorts`**: Extra ports to treat as MySQL. You rarely need this — Keploy detects MySQL automatically on any port. See [MySQL port detection](#mysql-port-detection).
+
+- **`disableMysqlAutoDetect`**: Turns off automatic MySQL port detection. Default is `false`.
+
+### MySQL port detection
+
+Keploy identifies MySQL on any port, so you do not have to tell it where your database listens. This matters when MySQL, or a MySQL wire-compatible service, runs somewhere other than the usual `3306` — a second instance on `3307`, ProxySQL on `6033`, MaxScale on `4006`, StarRocks on `9030`, or a Cloud SQL Auth Proxy on whatever port you gave it.
+
+Detection works differently in each mode, because each mode has different information available:
+
+- **During Record**, Keploy reads the first bytes the database server sends. MySQL greets a new connection with a handshake packet, so Keploy identifies the protocol from that greeting and routes the connection to its MySQL parser.
+
+- **During Test**, no database is running — Keploy serves the Mocks it recorded. It recovers the port from those Mocks, which store the address each connection was recorded against.
+
+Together this means a port you recorded on is replayed correctly with no configuration.
+
+#### When to set these fields
+
+Both fields are optional and most projects leave them alone.
+
+Set `mysqlPorts` to skip detection for a port you already know about. Keploy always treats `3306` and `4000` as MySQL; listing a port here adds it to that set. The only practical benefit is avoiding a short probe on the first connection to that port.
+
+```yaml
+mysqlPorts: [3307, 6033]
+```
+
+Set `disableMysqlAutoDetect` to `true` to turn detection off entirely and match `mysqlPorts` strictly:
+
+```yaml
+disableMysqlAutoDetect: true
+```
+
+With detection disabled, a MySQL server on a port outside `mysqlPorts` cannot complete its handshake, and your application fails to connect. Only disable detection if you also list every MySQL port your application uses.
 
 ### Test Section
 


### PR DESCRIPTION
## What has changed?

Documents automatic MySQL port detection, shipped in keploy/keploy#4389.

Keploy used to route MySQL to its parser purely by destination port — `3306` and `4000` by default, plus whatever `mysqlPorts` listed. MySQL on any other port (a second instance on `3307`, ProxySQL on `6033`, MaxScale on `4006`, StarRocks on `9030`, a Cloud SQL Auth Proxy) could not complete its handshake, and the application failed to connect.

Two documentation gaps made that worse than it needed to be:

1. **`mysqlPorts` was never documented anywhere.** It existed only in the source. A user hitting the problem had no discoverable fix.
2. **Nothing described the symptom.** The error users actually search for is `Lost connection to server at 'handshake: reading initial communication packet'`, and it appeared nowhere in the docs.

### Changes

**`running-keploy/configuration-file.md`**

- Adds `mysqlPorts` and `disableMysqlAutoDetect` to the sample config block, matching what `keploy config --generate` now emits.
- Adds a **MySQL port detection** section explaining how detection works in each mode — Keploy reads the server's handshake during Record, and recovers the port from recorded Mocks during Test (no database is running then, so the port cannot come from anywhere else).
- Documents when either field is worth setting, and warns that disabling detection means listing every MySQL port your application uses.

**`keploy-explained/common-errors.md`**

- Adds troubleshooting entry 12 for the stuck-handshake symptom, with the exact error string, both causes, and the fix. Cross-links to the section above.

This is a documentation-only change — no behaviour is described that isn't already merged or in review upstream.

This PR Resolves #(issue) — NA

## Type of change

- [x] Documentation update (if none of the other choices apply).

## How Has This Been Tested?

Both commands run clean locally:

- `npm run build` → exits 0, `[SUCCESS] Generated static files in "build"`, 205 documents processed, no broken-link warnings (the new relative link from the troubleshooting entry into the config reference anchor resolves).
- `npx prettier@2.8.8 --check` on both files → `All matched files use Prettier code style!`
- `vale 3.0.3 --config=.vale.ini` on both files → the only remaining alerts are on pre-existing lines I did not touch (`matchType`, `hardcoding`, `xml`, `json`, `traceroute`); CI runs with `filter_mode: diff_context`, so none of them apply to this diff. No alerts on any added line.

No screenshots attached — the change is prose and a config snippet with no new visual elements. Happy to add one of the rendered **MySQL port detection** section if you'd like it in the PR.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
