### PR TITLE
docs: update download URLs from S3 to Azure

### DIFF
--- a/versioned_docs/version-2.0.0/keploy-cloud/time-freezing.md
+++ b/versioned_docs/version-2.0.0/keploy-cloud/time-freezing.md
@@ -56,7 +56,7 @@ uname -a
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
 
 # set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_amd64
@@ -76,7 +76,7 @@ OR
 ```Dockerfile
 # Download the time freeze agent
 
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
 
 # set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_arm64
@@ -105,7 +105,7 @@ Voila! Your tests will now run with time freezing enabled.
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/freeze_time_amd64.so
@@ -120,7 +120,7 @@ OR
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_arm64.so /lib/keploy/freeze_time_arm64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_arm64.so /lib/keploy/freeze_time_arm64.so
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/freeze_time_arm64.so

--- a/versioned_docs/version-2.0.0/running-keploy/keploy-karaf.md
+++ b/versioned_docs/version-2.0.0/running-keploy/keploy-karaf.md
@@ -35,14 +35,14 @@ curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
 
 Use `wget` to download the necessary JAR files:
 
-- [io.keploy.agent-2.0.1.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar)
-- [org.jacoco.agent-0.8.12-runtime.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
+- [io.keploy.agent-2.0.1.jar](https://keployenterprise.blob.core.windows.net/agent-jars/io.keploy.agent-2.0.1.jar)
+- [org.jacoco.agent-0.8.12-runtime.jar](https://keployenterprise.blob.core.windows.net/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
 
 Run the following commands to download the files:
 
 ```bash
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
+wget https://keployenterprise.blob.core.windows.net/agent-jars/io.keploy.agent-2.0.1.jar
+wget https://keployenterprise.blob.core.windows.net/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
 ```
 
 ## Step 2: Configure Apache Karaf

--- a/versioned_docs/version-3.0.0/keploy-cloud/time-freezing.md
+++ b/versioned_docs/version-3.0.0/keploy-cloud/time-freezing.md
@@ -60,7 +60,7 @@ uname -a
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
 
 # set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_amd64
@@ -80,7 +80,7 @@ OR
 ```Dockerfile
 # Download the time freeze agent
 
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
 
 # set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_arm64
@@ -109,7 +109,7 @@ Voila! Your tests will now run with time freezing enabled.
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/freeze_time_amd64.so
@@ -124,7 +124,7 @@ OR
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_arm64.so /lib/keploy/freeze_time_arm64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_arm64.so /lib/keploy/freeze_time_arm64.so
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/freeze_time_arm64.so

--- a/versioned_docs/version-3.0.0/running-keploy/generate-api-tests-using-ai.md
+++ b/versioned_docs/version-3.0.0/running-keploy/generate-api-tests-using-ai.md
@@ -31,9 +31,9 @@ The Agent acts as a local interceptor that uses eBPF to record your service's in
 
 | Platform    | Steps                                                                                                                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS**   | - [Download](https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/Keploy+Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                                 |
-| **Linux**   | - Run the following in your terminal: <br /><br /> `curl -L -O https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/keploy-agent-linux-amd64.tar.gz` <br /><br /> `tar -xzf keploy-agent-linux-amd64.tar.gz` <br /><br /> `./keploy-agent` <br /><br /> |
-| **Windows** | - [Download](https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/Keploy+Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                                 |
+| **macOS**   | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                                 |
+| **Linux**   | - Run the following in your terminal: <br /><br /> `curl -L -O https://keploy.io/ent/dl/latest/keploy-agent-linux-amd64.tar.gz` <br /><br /> `tar -xzf keploy-agent-linux-amd64.tar.gz` <br /><br /> `./keploy-agent` <br /><br /> |
+| **Windows** | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                                 |
 
 > ✅ Once installed and running, return to the Keploy Console and hit **Generate API Tests**. The Keploy Agent creates a secure bridge to your local or private
 > environment, enabling our engine to interact with your service as if it were in production, capturing the underlying dependency calls (DB, 3rd party APIs) without code changes.

--- a/versioned_docs/version-3.0.0/running-keploy/generate-api-tests-using-ai.md
+++ b/versioned_docs/version-3.0.0/running-keploy/generate-api-tests-using-ai.md
@@ -29,14 +29,14 @@ The Agent acts as a local interceptor that uses eBPF to record your service's in
 
 ### Keploy Agent Installation
 
-| Platform    | Steps                                                                                                                                                                                                                                                                   |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS**   | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                                 |
+| Platform    | Steps                                                                                                                                                                                                                              |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **macOS**   | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                               |
 | **Linux**   | - Run the following in your terminal: <br /><br /> `curl -L -O https://keploy.io/ent/dl/latest/keploy-agent-linux-amd64.tar.gz` <br /><br /> `tar -xzf keploy-agent-linux-amd64.tar.gz` <br /><br /> `./keploy-agent` <br /><br /> |
-| **Windows** | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                                 |
+| **Windows** | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                               |
 
 > ✅ Once installed and running, return to the Keploy Console and hit **Generate API Tests**. The Keploy Agent creates a secure bridge to your local or private
-> environment, enabling our engine to interact with your service as if it were in production, capturing the underlying dependency calls (DB, 3rd party APIs) without code changes.
+> environment, enabling our engine to interact with your service as if it were in production, capturing the underlying dependency calls (DB, third-party APIs) without code changes.
 
 ## BEST Practices for BEST Test Output
 

--- a/versioned_docs/version-3.0.0/running-keploy/keploy-karaf.md
+++ b/versioned_docs/version-3.0.0/running-keploy/keploy-karaf.md
@@ -35,14 +35,14 @@ curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
 
 Use `wget` to download the necessary JAR files:
 
-- [io.keploy.agent-2.0.1.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar)
-- [org.jacoco.agent-0.8.12-runtime.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
+- [io.keploy.agent-2.0.1.jar](https://keployenterprise.blob.core.windows.net/agent-jars/io.keploy.agent-2.0.1.jar)
+- [org.jacoco.agent-0.8.12-runtime.jar](https://keployenterprise.blob.core.windows.net/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
 
 Run the following commands to download the files:
 
 ```bash
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.1.jar
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
+wget https://keployenterprise.blob.core.windows.net/agent-jars/io.keploy.agent-2.0.1.jar
+wget https://keployenterprise.blob.core.windows.net/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
 ```
 
 ## Step 2: Configure Apache Karaf

--- a/versioned_docs/version-4.0.0/keploy-cloud/time-freezing.md
+++ b/versioned_docs/version-4.0.0/keploy-cloud/time-freezing.md
@@ -61,7 +61,7 @@ uname -a
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
 
 # set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_amd64
@@ -81,7 +81,7 @@ OR
 ```Dockerfile
 # Download the time freeze agent
 
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
 
 # set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_arm64
@@ -110,7 +110,7 @@ Voila! Your tests will now run with time freezing enabled.
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/freeze_time_amd64.so
@@ -125,7 +125,7 @@ OR
 
 ```Dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_arm64.so /lib/keploy/freeze_time_arm64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_arm64.so /lib/keploy/freeze_time_arm64.so
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/freeze_time_arm64.so

--- a/versioned_docs/version-4.0.0/running-keploy/generate-api-tests-using-ai.md
+++ b/versioned_docs/version-4.0.0/running-keploy/generate-api-tests-using-ai.md
@@ -29,9 +29,9 @@ If your API is not publicly accessible, Keploy will show a warning when attempti
 
 | Platform    | Steps                                                                                                                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS**   | - [Download](https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/Keploy+Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                                 |
-| **Linux**   | - Run the following in your terminal: <br /><br /> `curl -L -O https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/keploy-agent-linux-amd64.tar.gz` <br /><br /> `tar -xzf keploy-agent-linux-amd64.tar.gz` <br /><br /> `./keploy-agent` <br /><br /> |
-| **Windows** | - [Download](https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/Keploy+Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                                 |
+| **macOS**   | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                                 |
+| **Linux**   | - Run the following in your terminal: <br /><br /> `curl -L -O https://keploy.io/ent/dl/latest/keploy-agent-linux-amd64.tar.gz` <br /><br /> `tar -xzf keploy-agent-linux-amd64.tar.gz` <br /><br /> `./keploy-agent` <br /><br /> |
+| **Windows** | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                                 |
 
 > ✅ Once installed and running, return to the Keploy Console and hit **Generate API Tests**. The agent will proxy your local API to allow secure test generation.
 

--- a/versioned_docs/version-4.0.0/running-keploy/generate-api-tests-using-ai.md
+++ b/versioned_docs/version-4.0.0/running-keploy/generate-api-tests-using-ai.md
@@ -27,11 +27,11 @@ If your API is not publicly accessible, Keploy will show a warning when attempti
 
 ### Keploy Agent Installation
 
-| Platform    | Steps                                                                                                                                                                                                                                                                   |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS**   | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                                 |
+| Platform    | Steps                                                                                                                                                                                                                              |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **macOS**   | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent.dmg) <br /><br /> - Open the `.dmg` file and install the app normally. <br /><br /> - Launch the Keploy Agent after installation. <br />                               |
 | **Linux**   | - Run the following in your terminal: <br /><br /> `curl -L -O https://keploy.io/ent/dl/latest/keploy-agent-linux-amd64.tar.gz` <br /><br /> `tar -xzf keploy-agent-linux-amd64.tar.gz` <br /><br /> `./keploy-agent` <br /><br /> |
-| **Windows** | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                                 |
+| **Windows** | - [Download](https://keploy.io/ent/dl/latest/Keploy%20Agent-windows_amd64.zip) <br /><br /> Extract the zip file and Launch the Keploy Agent. <br />                                                                               |
 
 > ✅ Once installed and running, return to the Keploy Console and hit **Generate API Tests**. The agent will proxy your local API to allow secure test generation.
 

--- a/versioned_docs/version-4.0.0/running-keploy/keploy-karaf.md
+++ b/versioned_docs/version-4.0.0/running-keploy/keploy-karaf.md
@@ -35,14 +35,14 @@ curl --silent -O -L https://keploy.io/ent/install.sh && source install.sh
 
 Use `wget` to download the necessary JAR files:
 
-- [io.keploy.agent-2.0.2.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.2.jar)
-- [org.jacoco.agent-0.8.12-runtime.jar](https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
+- [io.keploy.agent-2.0.2.jar](https://keployenterprise.blob.core.windows.net/agent-jars/io.keploy.agent-2.0.2.jar)
+- [org.jacoco.agent-0.8.12-runtime.jar](https://keployenterprise.blob.core.windows.net/agent-jars/org.jacoco.agent-0.8.12-runtime.jar)
 
 Run the following commands to download the files:
 
 ```bash
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/io.keploy.agent-2.0.2.jar
-wget https://keploy-enterprise.s3.us-west-2.amazonaws.com/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
+wget https://keployenterprise.blob.core.windows.net/agent-jars/io.keploy.agent-2.0.2.jar
+wget https://keployenterprise.blob.core.windows.net/agent-jars/org.jacoco.agent-0.8.12-runtime.jar
 ```
 
 ## Step 2: Configure Apache Karaf


### PR DESCRIPTION
Download hosting has moved from the keploy-enterprise S3 bucket (us-west-2) to Azure: user-facing download links now use keploy.io/ent/dl and Dockerfile ADD snippets and agent JARs use the keployenterprise blob storage directly. The S3 bucket is being decommissioned. All rewritten URLs were verified serving (HTTP 206).