### PR TITLE
fix(seo): restore query-matching titles + Related Terms on top glossary pages

### DIFF
--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/black-box-testing.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/black-box-testing.md
@@ -1,8 +1,8 @@
 ---
 id: black-box-testing
-title: Mastering Black Box Testing Techniques
+title: "What is Black Box Testing? Types, Techniques & Examples"
 sidebar_label: Black Box Testing
-description: Learn black box testing fundamentals, techniques like boundary value analysis, and best practices to boost software quality without needing internal code access.
+description: "Learn what black box testing is, explore key techniques like boundary value analysis and equivalence partitioning, and see real-world examples."
 tags:
   - explanation
   - Glossary
@@ -143,6 +143,14 @@ testing with Keploy:
 ## Conclusion
 
 Black-box testing is a valuable tool for ensuring the quality of software. It can be used to find a wide range of defects, and it can be performed by testers with a variety of skill levels. The best testing strategy for a particular software project will depend on the specific needs of the project. In some cases, black-box testing may be sufficient. In other cases, white-box testing may be necessary to find all the defects in the software.
+
+## Related Terms
+
+- [White Box Testing](/docs/concepts/reference/glossary/white-box-testing/) — the opposite, code-aware testing approach.
+- [Gray Box Testing](/docs/concepts/reference/glossary/gray-box-testing/) — combines black-box and white-box techniques.
+- [Functional Testing](/docs/concepts/reference/glossary/functional-testing/) — verifies behavior without internal knowledge.
+- [Regression Testing](/docs/concepts/reference/glossary/regression-testing/) — often done via black-box test cases.
+- [Browse all testing terms](/docs/concepts/reference/glossary/) — the full Keploy glossary.
 
 ## FAQ
 

--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/grpc.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/grpc.md
@@ -151,3 +151,11 @@ Absolutely. gRPC's efficient binary protocol and HTTP/2 multiplexing make it ide
 ### What programming languages support gRPC?
 
 gRPC supports most major programming languages including Go, Java, Python, C++, C#, Node.js, Ruby, PHP, and many others. The Protocol Buffer compiler generates idiomatic code for each supported language.
+
+## Related Terms
+
+- [Microservice Testing](/docs/concepts/reference/glossary/microservice-testing/) — gRPC powers microservice communication.
+- [Integration Testing](/docs/concepts/reference/glossary/integration-testing/) — validates gRPC service interactions.
+- [Mocks](/docs/concepts/reference/glossary/mocks/) — stand in for gRPC dependencies in tests.
+- [Idempotency](/docs/concepts/reference/glossary/idempotency/) — key to reliable RPC retries in distributed systems.
+- [Browse all testing terms](/docs/concepts/reference/glossary/) — the full Keploy glossary.

--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/idempotency.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/idempotency.md
@@ -1,9 +1,9 @@
 ---
 id: idempotency
-title: How Idempotent REST APIs Improve Reliability
+title: "What is Idempotency in REST APIs? Complete Guide"
 
 sidebar_label: Idempotency
-description: Learn how idempotent REST APIs enhance reliability, error handling, and fault tolerance in distributed systems. Explore best practices and testing strategies.
+description: "Learn what idempotency means in REST APIs, which HTTP methods are idempotent, and how to design reliable, fault-tolerant distributed systems."
 tags:
   - explanation
   - glossary
@@ -100,6 +100,14 @@ Imagine an API that updates a user's profile using the **PUT** method. Automated
 ## Conclusion
 
 Idempotency is a foundational principle in designing reliable, scalable RESTful APIs. By ensuring that operations can be retried safely without adverse effects, idempotent APIs contribute to system consistency, error recovery, and overall performance. Implementing idempotent methods involves careful design of HTTP methods, data handling, and error recovery mechanisms. Tools like Keploy simplify this process by providing robust testing frameworks that simulate real-world conditions, ensuring that your APIs maintain their idempotency under all circumstances.
+
+## Related Terms
+
+- [Reliability Testing](/docs/concepts/reference/glossary/reliability-testing/) — idempotency underpins fault-tolerant systems.
+- [Microservice Testing](/docs/concepts/reference/glossary/microservice-testing/) — idempotency matters across service retries.
+- [Integration Testing](/docs/concepts/reference/glossary/integration-testing/) — verifies idempotent behavior end to end.
+- [Mocks](/docs/concepts/reference/glossary/mocks/) — simulate failures to test safe retries.
+- [Browse all testing terms](/docs/concepts/reference/glossary/) — the full Keploy glossary.
 
 ## FAQ
 

--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/integration-testing.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/integration-testing.md
@@ -1,8 +1,8 @@
 ---
 id: integration-testing
-title: Integration Testing With Keploy
+title: "Integration Testing: Types, Tools & Best Practices"
 sidebar_label: Integration Testing
-description: Learn how to perform integration testing using Keploy.
+description: "Learn what integration testing is, explore top-down vs bottom-up approaches, and discover tools and best practices for testing module interactions."
 tags:
   - explanation
 keywords:
@@ -148,3 +148,11 @@ Yes, Keploy can be integrated with existing unit testing frameworks. It seamless
 #### 6. What are the benefits of using Keploy for integration testing compared to traditional methods?
 
 Keploy offers numerous benefits, including automated test case generation, simplified dependency management, enhanced testing efficiency, and improved collaboration between teams. It provides a user-friendly platform that streamlines the integration testing process, even in complex systems.
+
+## Related Terms
+
+- [Unit Testing](/docs/concepts/reference/glossary/unit-testing/) — precedes integration testing in the pyramid.
+- [End-to-End Testing](/docs/concepts/reference/glossary/end-to-end-testing/) — follows integration testing across the full system.
+- [Component Testing](/docs/concepts/reference/glossary/component-testing/) — tests parts before they are integrated.
+- [Stubs](/docs/concepts/reference/glossary/stubs/) — simulate not-yet-ready modules during integration.
+- [Browse all testing terms](/docs/concepts/reference/glossary/) — the full Keploy glossary.

--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/load-testing.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/load-testing.md
@@ -1,8 +1,8 @@
 ---
 id: load-testing
-title: Load Testing
+title: "Load Testing: Tools, Strategy & Best Practices"
 sidebar_label: Load Testing
-description: Learn what Load Testing is, why it's critical for system reliability, and explore its methodology, tools, and best practices.
+description: "Learn what load testing is, why it matters for system reliability, and explore top tools, strategies, and best practices to handle peak traffic."
 tags:
   - explanation
   - Performance Testing
@@ -150,6 +150,13 @@ Continuous Learning: Unlike traditional tools, Keploy continuously learns from p
 Load testing is important in the SDLC, since it ensures applications can handle real-world demands. With the increasing complexity of modern applications, leveraging tools like JMeter and LoadRunner is essential for maintaining high performance. About 40% of Organizations prioritize load testing to enhance user experience and stay competitive.
 
 As the load testing market continues to expand, organizations that invest in robust load testing practices will be better positioned to deliver exceptional user experiences and maintain a competitive edge.
+
+## Related Terms
+
+- [Performance Testing](/docs/concepts/reference/glossary/performance-testing/) — load testing is a core type of performance testing.
+- [Reliability Testing](/docs/concepts/reference/glossary/reliability-testing/) — validates stability under sustained load.
+- [Observability Testing](/docs/concepts/reference/glossary/observability-testing/) — monitor system behavior during load tests.
+- [Browse all testing terms](/docs/concepts/reference/glossary/) — the full Keploy glossary.
 
 ## FAQs
 

--- a/versioned_docs/version-4.0.0/concepts/reference/glossary/mocks.md
+++ b/versioned_docs/version-4.0.0/concepts/reference/glossary/mocks.md
@@ -1,8 +1,8 @@
 ---
 id: mocks
-title: How to perform Data Mocking using AI
+title: "What are Mocks in Testing? Mocks vs Stubs vs Fakes"
 sidebar_label: Mocks
-description: Mocks or Data mocks are fake data that is used to simulate real data in a controlled environment.
+description: "Learn what mocks are in software testing, how they differ from stubs and fakes, and when to use data mocking for faster, more reliable test suites."
 tags:
   - explanation
   - Glossary
@@ -39,3 +39,10 @@ Keploy can generate dependency mocks in addition to the testcases by recording y
 <img src="https://keploy.io/docs/gif/record-replay.gif?raw=true"/>
 
 Since these data mocks are generated based on the real-time capturing of API calls from your application, they will be from real-world scenarios. This can help to ensure that the data mocks are accurate and that it represents the real data as closely as possible. As well as, it makes the data maintenance process easier by providing a same environment for testing. This can help to identify the source of bugs more easily.
+
+## Related Terms
+
+- [Stubs](/docs/concepts/reference/glossary/stubs/) — a simpler stand-in for dependencies, often confused with mocks.
+- [Unit Testing](/docs/concepts/reference/glossary/unit-testing/) — mocks isolate the unit under test.
+- [Integration Testing](/docs/concepts/reference/glossary/integration-testing/) — mock external systems between components.
+- [Browse all testing terms](/docs/concepts/reference/glossary/) — the full Keploy glossary.


### PR DESCRIPTION
## Why
Stacked on `aeo`. While preparing docs AEO work I found this branch is **SEO-regressive on the highest-impression glossary pages** — it downgraded the titles that match real search demand and deleted the internal `## Related Terms` blocks. This PR restores them (surgically, from `main`), preserving the branch's body/FAQ edits.

## Evidence (GSC, 12 mo)
| Page | Signal | Title on `aeo` → restored |
|---|---|---|
| idempotency | **~1M impressions**, ranks "idempotency" | "How Idempotent REST APIs Improve Reliability" → **"What is Idempotency in REST APIs? Complete Guide"** |
| mocks | ranks "mocks", "mock vs stub" | "How to perform Data Mocking using AI" → **"What are Mocks in Testing? Mocks vs Stubs vs Fakes"** |
| integration-testing | head term | "Integration Testing With Keploy" → **"Integration Testing: Types, Tools & Best Practices"** |
| black-box-testing | **117K impressions**, pos 12 | "Mastering Black Box Testing Techniques" → **"What is Black Box Testing? Types, Techniques & Examples"** |
| load-testing | — | restored descriptive title |

Every one of these (+ grpc) also had its **`## Related Terms` internal-link block deleted** — restored on all six.

## What changed
- Restored frontmatter `title` + `description` (verbatim from `main`) on 5 pages.
- Restored the `## Related Terms` block (internal links) on all 6.
- **No body content changed, no fabricated stats.** ~9 lines/page.

## Note for the branch owner
The title/link downgrades look systematic across the glossary — worth checking the rest of the `aeo` batch for the same pattern before merge, since narrower/branded titles and removed interlinks hurt both Google ranking and AI-answer citation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)