### PR TITLE
docs: document the Community sign-in requirement and fix Windows install

### DIFF
--- a/versioned_docs/version-4.0.0/installation/linux.md
+++ b/versioned_docs/version-4.0.0/installation/linux.md
@@ -22,12 +22,24 @@ Run the following command in your terminal:
 curl --silent -O -L https://keploy.io/install.sh && source install.sh
 ```
 
+:::note Keploy Community needs a free account
+
+`keploy record` and `keploy test` sign you in before they run. The first time you use either, Keploy prints a URL and opens your browser at [app.keploy.io](https://app.keploy.io) to sign in; the session is then cached in `~/.keploy/tokens.yaml` and reused.
+
+- **No browser available** (a remote shell, a container): run with `--manual-login` and paste an API key from your Keploy dashboard when prompted.
+- **CI, or any non-interactive run**: set `KEPLOY_API_KEY` (or pass `--api-key`) and Keploy skips the sign-in prompt entirely.
+- **Offline**: the local mock loop — `keploy mock record --local` and `keploy mock replay --local` — is the one pair that runs without signing in. While you are signed out it logs a harmless `failed to validate user role` line and then runs normally. This is the mock loop, not a replacement for `keploy record` and `keploy test` — see [Mock your tests](/docs/running-keploy/mock-your-tests).
+
+A free account is enough to record and replay. Free-tier runs are subject to a usage allowance.
+
+:::
+
 ## 2. Verify Installation
 
 After installation, check if Keploy is working by running:
 
 ```bash
-keploy version
+keploy --version
 ```
 
 ✅ If you see the version number, Keploy has been installed successfully!

--- a/versioned_docs/version-4.0.0/installation/macos.md
+++ b/versioned_docs/version-4.0.0/installation/macos.md
@@ -19,6 +19,18 @@ Keploy now runs **natively on macOS** — you can record and replay an app that 
 
 Native macOS support covers **Go, Node.js, Python and Java** apps, including their HTTPS traffic. Docker and Lima remain available if you prefer to run your app in a container.
 
+:::note Keploy Community needs a free account
+
+`keploy record` and `keploy test` sign you in before they run. The first time you use either, Keploy prints a URL and opens your browser at [app.keploy.io](https://app.keploy.io) to sign in; the session is then cached in `~/.keploy/tokens.yaml` and reused.
+
+- **No browser available** (a remote shell, a container): run with `--manual-login` and paste an API key from your Keploy dashboard when prompted.
+- **CI, or any non-interactive run**: set `KEPLOY_API_KEY` (or pass `--api-key`) and Keploy skips the sign-in prompt entirely.
+- **Offline**: the local mock loop — `keploy mock record --local` and `keploy mock replay --local` — is the one pair that runs without signing in. While you are signed out it logs a harmless `failed to validate user role` line and then runs normally. This is the mock loop, not a replacement for `keploy record` and `keploy test` — see [Mock your tests](/docs/running-keploy/mock-your-tests).
+
+A free account is enough to record and replay. Free-tier runs are subject to a usage allowance.
+
+:::
+
 👉 **Choose your preferred method:**
 
 - [Option 1: Run Keploy natively (recommended)](#option-1-run-keploy-natively)
@@ -101,7 +113,7 @@ Native macOS support covers **Go, Node.js, Python and Java** apps, including the
 7. **Verify the installation**
 
    ```bash
-   keploy version
+   keploy --version
    ```
 
 ✅ If the version shows up, Keploy is installed successfully!
@@ -134,7 +146,7 @@ Begin recording your API calls and automatically generate test cases with Keploy
 4. **Verify the installation**
 
    ```bash
-   keploy version
+   keploy --version
    ```
 
 ✅ If the version shows up, Keploy is installed successfully!

--- a/versioned_docs/version-4.0.0/installation/windows.md
+++ b/versioned_docs/version-4.0.0/installation/windows.md
@@ -21,6 +21,18 @@ Keploy runs **natively on Windows** — you can record and replay an app that ru
 
 Native Windows support covers apps in **Go, Node.js, Python and Java**. WSL and Docker remain available if you prefer them.
 
+:::note Keploy Community needs a free account
+
+`keploy record` and `keploy test` sign you in before they run. The first time you use either, Keploy prints a URL and opens your browser at [app.keploy.io](https://app.keploy.io) to sign in; the session is then cached in `%USERPROFILE%\.keploy\tokens.yaml` and reused.
+
+- **No browser available** (a remote shell, a container): run with `--manual-login` and paste an API key from your Keploy dashboard when prompted.
+- **CI, or any non-interactive run**: set `KEPLOY_API_KEY` (or pass `--api-key`) and Keploy skips the sign-in prompt entirely.
+- **Offline**: the local mock loop — `keploy mock record --local` and `keploy mock replay --local` — is the one pair that runs without signing in. While you are signed out it logs a harmless `failed to validate user role` line and then runs normally. This is the mock loop, not a replacement for `keploy record` and `keploy test` — see [Mock your tests](/docs/running-keploy/mock-your-tests).
+
+A free account is enough to record and replay. Free-tier runs are subject to a usage allowance.
+
+:::
+
 👉 **Choose your preferred method:**
 
 - [Option 1: Run Keploy natively (recommended)](#option-1-run-keploy-natively)
@@ -31,7 +43,32 @@ Native Windows support covers apps in **Go, Node.js, Python and Java**. WSL and 
 
 ## Option 1: Run Keploy natively
 
-1. **Install Keploy** — download the Windows build from the [releases page](https://github.com/keploy/keploy/releases) (or your Keploy distribution) and put `keploy.exe` on your `PATH`.
+1. **Install Keploy.** The quickest route is Git Bash, which installs the Community build and puts it on your `PATH` for you:
+
+   ```bash
+   curl --silent -O -L https://keploy.io/install.sh && source install.sh
+   ```
+
+   Or download it manually in PowerShell:
+
+   ```powershell
+   $ProgressPreference = 'SilentlyContinue'
+   $dir = "$env:USERPROFILE\.keploy\bin"
+   New-Item -ItemType Directory -Force $dir | Out-Null
+   Invoke-WebRequest -Uri "https://keploy.io/ent/dl/latest/enterprise_windows_amd64.exe" `
+     -OutFile "$dir\keploy.exe"
+   Unblock-File "$dir\keploy.exe"
+   $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+   if ($userPath -notlike "*$dir*") {
+     [Environment]::SetEnvironmentVariable("Path", "$userPath;$dir", "User")
+   }
+   ```
+
+   Open a new terminal so the updated `Path` takes effect, then check it with `keploy --version`.
+
+   **Use the Community build for native Windows.** Native Windows interception ships in the Community build that both routes above install. Its download is named `enterprise_windows_amd64.exe` for historical reasons — a free account is all you need. The `keploy_windows_amd64` asset on the [GitHub releases page](https://github.com/keploy/keploy/releases) is a different, OSS build that intercepts with eBPF and so refuses a native Windows run with _"not supported by this build of Keploy"_. Use that asset only if you are running Keploy inside Docker.
+
+   **If Windows blocks the download.** The Windows build is not yet code-signed, so SmartScreen may show "Windows protected your PC" on first run. The `Unblock-File` line above clears the download marker; if you fetched the binary another way, right-click it, choose **Properties**, and tick **Unblock**.
 
 2. **Open a terminal.** An ordinary PowerShell or Terminal window is enough — Keploy does not need to run elevated.
 
@@ -99,7 +136,7 @@ If you already have WSL, Go to Step 2.
 3. **Verify Installation**
 
    ```bash
-   keploy version
+   keploy --version
    ```
 
    ✅ If you see the version number, Keploy is installed successfully!
@@ -132,7 +169,7 @@ Begin recording your API calls and automatically generate test cases with Keploy
 4. **Verify the installation**
 
    ```bash
-   keploy version
+   keploy --version
    ```
 
 ✅ If the version shows up, Keploy is installed successfully!


### PR DESCRIPTION
> **Do not merge until keploy/enterprise#2560 is released** to `keploy.io/ent/install.sh`. This page makes the installer the primary Windows route; the live script still prints `Windows not supported please run on WSL2`. Re-`curl` it to confirm before merging.

## Three bugs, all reproduced

**1. The sign-in requirement appears in zero install docs.** `keploy record` and `keploy test` authenticate before they run — with no credentials they open a browser at `app.keploy.io` and block. The macOS page ends *"Wohoo! You are all set to use Keploy"* immediately before the first command that does this.

```
$ keploy record -c "echo hi"
Opening browser for authentication...
Waiting for authentication...
```

**2. `keploy version` is not a command** — and the install pages told every new user to run it as their first step after installing.

```
$ keploy version
Error: unknown command "version" for "keploy"
$ keploy --version
Keploy 3.8.25
```

**3. The Windows page pointed at the wrong binary.** It said to download from the GitHub releases page. That asset is the OSS build, which intercepts with eBPF and refuses a native Windows run — so the reader hit a wall on the very next command the page tells them to type.

```
$ strings keploy_windows_amd64 | grep -c keploy_winshim
0
$ strings keploy_windows_amd64 | grep -c "eBPF hooks are not supported on non-Linux"
1
```

## Changes

- **Sign-in note** on the macOS, Linux and Windows pages: browser sign-in, `--manual-login` (which prompts for an API key — it does not paste a code), `KEPLOY_API_KEY` for CI, and the local mock loop as the sign-in-free path. It notes the harmless `failed to validate user role` line that loop currently logs while signed out.
- **Free-tier wording** says runs are subject to a usage allowance rather than promising no gate, because `keploy test` goes through `CheckITUsageAllowed` and can return `test run blocked due to usage limit`.
- **`keploy version` → `keploy --version`** in all six places across the three pages.
- **Windows Option 1** now leads with the installer, keeps a PowerShell download as the manual fallback (idempotent `Path` append, `Unblock-File`, `$ProgressPreference`), explains that the `enterprise_windows_amd64.exe` filename is historical and a free account is enough, and warns that the build is not yet code-signed so SmartScreen may flag it.

## Verified

- `npx prettier@2.8.8 --check` — passes (the repo's `prettify_code.yml` gate)
- Vale 3.0.3 with the repo's `.vale.ini` — 0 errors, 0 warnings, 0 suggestions
- Full `npm run build` — SUCCESS, 207 documents
- Rendered HTML checked: Option 1 is one unbroken `<ol>`, backslashes render literally (`$env:USERPROFILE\.keploy\bin`), no bare `keploy version` remains in `version-4.0.0`

`version-3.0.0` still contains `keploy version`, but it is excluded from `onlyIncludeVersions` and not built, so it is out of scope here.